### PR TITLE
Integrate priority-based buffer into `Client` and `Server`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,9 @@
 **/bin
 *.suo
 */.vs
+.vs
 *.pdb
+packages
 
 # Scarlet: Logs
 **/Logs

--- a/Communications/Client.cs
+++ b/Communications/Client.cs
@@ -444,8 +444,7 @@ namespace Scarlet.Communications
             if (!Initialized) { throw new InvalidOperationException("Client not initialized. Please call Client.Start() to establish connection. first"); }
 
             // Check if we have stopped the process
-            if (StopProcesses)
-                return false;
+            if (StopProcesses) { return false; }
             else
             {
                 // Ensure that cloning the packet will not try to clone a null string

--- a/Communications/Client.cs
+++ b/Communications/Client.cs
@@ -30,7 +30,7 @@ namespace Scarlet.Communications
 
         private static PacketBuffer SendQueue; // Buffer of packets waiting to be sent
         private static QueueBuffer ReceiveQueue; // Buffer of received packets waiting to be processed
-        private static PacketPriority DefaultPriority; // Default packet priority
+        public static PacketPriority DefaultPriority { get; private set; } // Default packet priority
 
         private static Thread SendThread, ProcessThread; // Threads for sending and parsing/processing
         private static Thread ReceiveThreadUDP, ReceiveThreadTCP; // Threads for receiving on TCP and UDP

--- a/Communications/Client.cs
+++ b/Communications/Client.cs
@@ -62,10 +62,10 @@ namespace Scarlet.Communications
         /// <param name="PortTCP"> Target port for TCP Communications on the server.</param>
         /// <param name="PortUDP"> Target port for UDP Communications on the server.</param>
         /// <param name="Name"> Name of client. </param>
-        /// <param name="UsePriorityQueue"> If it is true, use `GenericController` as sending buffer. Use `QueueBuffer` otherwise. </param>
         /// <param name="ReceiveBufferSize"> Size of buffer for incoming packet. Unit: byte </param>
         /// <param name="OperationPeriod"> Time to wait after receiving or sending each packet. Unit: ms </param>
-        public static void Start(string ServerIP, int PortTCP, int PortUDP, string Name, bool UsePriorityQueue = true, int ReceiveBufferSize = 64, int OperationPeriod = 20)
+        /// <param name="UsePriorityQueue"> If it is true, packet priority control will be enabled. </param>
+        public static void Start(string ServerIP, int PortTCP, int PortUDP, string Name, int ReceiveBufferSize = 64, int OperationPeriod = 20, bool UsePriorityQueue = false)
         {
             // Initialize PacketHandler
             PacketHandler.Start();
@@ -410,8 +410,10 @@ namespace Scarlet.Communications
                 Packet CurrentPacket = ReceiveQueue.Dequeue();
                 if (CurrentPacket != null)
                 {
-                    // Parses the message
+                    // Make sure endpoint is set
                     CurrentPacket.Endpoint = CurrentPacket.Endpoint ?? "Server";
+
+                    // Parses the message
                     Parse.ParseMessage(CurrentPacket);
                 }
 
@@ -436,12 +438,10 @@ namespace Scarlet.Communications
         public static bool Send(Packet SendPacket, PacketPriority Priority = PacketPriority.USE_DEFAULT)
         {
             // Use default priority if needed
-            if (Priority == PacketPriority.USE_DEFAULT)
-                Priority = DefaultPriority;
+            if (Priority == PacketPriority.USE_DEFAULT) { Priority = DefaultPriority; }
 
             // Check initialization status of Client.
-            if (!Initialized)
-                throw new InvalidOperationException("Client not initialized. Please call Client.Start() to establish connection. first");
+            if (!Initialized) { throw new InvalidOperationException("Client not initialized. Please call Client.Start() to establish connection. first"); }
 
             // Check if we have stopped the process
             if (StopProcesses)

--- a/Communications/Client.cs
+++ b/Communications/Client.cs
@@ -536,10 +536,7 @@ namespace Scarlet.Communications
                 // Send packet only if packet is not empty (i.e. buffer is not empty)
                 if (ToSend != null)
                 {
-                    try
-                    {
-                        SendNow(ToSend); // Try to send the packet
-                    }
+                    try { SendNow(ToSend); } // Try to send the packet
                     catch (Exception Exception)
                     {
                         if (IsConnected) // Log an exception if the client is supposedly connected (so we don't bog down the console)

--- a/Communications/Constants.cs
+++ b/Communications/Constants.cs
@@ -7,10 +7,10 @@
     {
         USE_DEFAULT = -1,
         EMERGENT = 0,
-        HIGH,
-        MEDIUM,
-        LOW,
-        LOWEST
+        HIGH = 1,
+        MEDIUM = 2,
+        LOW = 3,
+        LOWEST = 4
     }
 
     static class Constants

--- a/Communications/Constants.cs
+++ b/Communications/Constants.cs
@@ -1,5 +1,8 @@
 ﻿namespace Scarlet.Communications
 {
+    /// <summary>
+    /// Represents the priority of packet, from highest to lowest.
+    /// </summary>
     public enum PacketPriority
     {
         USE_DEFAULT = -1,

--- a/Communications/Constants.cs
+++ b/Communications/Constants.cs
@@ -1,5 +1,15 @@
 ﻿namespace Scarlet.Communications
 {
+    public enum PacketPriority
+    {
+        USE_DEFAULT = -1,
+        EMERGENT = 0,
+        HIGH,
+        MEDIUM,
+        LOW,
+        LOWEST
+    }
+
     static class Constants
     {
         #region Communication Defaults

--- a/Communications/Packet.cs
+++ b/Communications/Packet.cs
@@ -55,6 +55,16 @@ namespace Scarlet.Communications
         }
 
         /// <summary>
+        /// Return the length of packet in bytes.
+        /// </summary>
+        /// 
+        /// <returns> Length of packet in bytes. </returns>
+        public int GetLength()
+        {
+            return GetForSend().Length;
+        }
+
+        /// <summary>
         /// Updates the packet timestamp to the current time
         /// </summary>
         public void UpdateTimestamp()

--- a/Communications/Packet.cs
+++ b/Communications/Packet.cs
@@ -54,10 +54,7 @@ namespace Scarlet.Communications
             return this.Data.GetRawData();
         }
 
-        /// <summary>
-        /// Return the length of packet in bytes.
-        /// </summary>
-        /// 
+        /// <summary> Return the length of packet in bytes. </summary>
         /// <returns> Length of packet in bytes. </returns>
         public int GetLength()
         {

--- a/Communications/Packet.cs
+++ b/Communications/Packet.cs
@@ -56,18 +56,12 @@ namespace Scarlet.Communications
 
         /// <summary> Return the length of packet in bytes. </summary>
         /// <returns> Length of packet in bytes. </returns>
-        public int GetLength()
-        {
-            return GetForSend().Length;
-        }
+        public int GetLength() { return GetForSend().Length; }
 
         /// <summary>
         /// Updates the packet timestamp to the current time
         /// </summary>
-        public void UpdateTimestamp()
-        {
-            Data.SetTime(GetCurrentTime());
-        }
+        public void UpdateTimestamp() { this.Data.SetTime(GetCurrentTime()); }
 
         /// <summary>
         /// Gets the current time as a byte array for use in packets.

--- a/Communications/PacketBuffer.cs
+++ b/Communications/PacketBuffer.cs
@@ -50,7 +50,7 @@ namespace Scarlet.Communications
         /// <returns> true if buffer is empty, false otherwise. </returns>
         public bool IsEmpty()
         {
-            return Peek() != null;
+            return Peek() == null;
         }
     }
 
@@ -442,7 +442,6 @@ namespace Scarlet.Communications
     /// </summary>
     public class GenericController : PacketBuffer
     {
-        public enum Priority { EMERGENT, HIGH, MEDIUM, LOW, LOWEST };
         public readonly QueueBuffer[] Buffers;
         public readonly PriorityBuffer PriorityBuffer;
         public readonly BandwidthControlBuffer BandwidthBuffer;
@@ -488,7 +487,7 @@ namespace Scarlet.Communications
         /// <param name="Priority"> Priority of packet. </param>
         /// 
         /// <exception cref="ArgumentOutOfRangeException"> If priority is out of range. </exception>
-        public void Enqueue(Packet Packet, Priority priority = Priority.MEDIUM)
+        public void Enqueue(Packet Packet, PacketPriority priority = PacketPriority.MEDIUM)
         {
             if (priority < 0 || (int)priority >= 5)
                 throw new ArgumentOutOfRangeException("Priority number is out of range");

--- a/Communications/PacketBuffer.cs
+++ b/Communications/PacketBuffer.cs
@@ -1,0 +1,472 @@
+﻿using System;
+using System.Collections.Generic;
+using Scarlet.Communications;
+
+namespace Scarlet.Communications
+{
+    /// <summary>
+    /// This defines the interface of packet buffer.
+    /// </summary>
+    public abstract class PacketBuffer
+    {
+        /// <summary>
+        /// Add a packet to buffer.
+        /// </summary>
+        /// 
+        /// <param name="Packet"> The packet to add. </param>
+        /// <param name="Priority"> Priority of packet. </param>
+        public abstract void Enqueue(Packet Packet, int Priority);
+
+        /// <summary>
+        /// Get next packet without removing it.
+        /// </summary>
+        /// 
+        /// <remarks>
+        /// It will return null if the buffer is empty instead of throwing an exception.
+        /// </remarks>
+        /// 
+        /// <returns> Next packet if buffer is not empty, or null otherwise. </returns>
+        public abstract Packet Peek();
+
+        /// <summary>
+        /// Get next packet and remove it.
+        /// </summary>
+        /// 
+        /// <remarks>
+        /// It will return null if the buffer is empty instead of throwing an exception.
+        /// </remarks>
+        /// 
+        /// <returns> Next packet if buffer is not empty, or null otherwise. </returns>
+        public abstract Packet Dequeue();
+    }
+
+    /// <summary>
+    /// This class is a basic packet buffer. It is just a queue with thread safty guarantee.
+    /// </summary>
+    public class QueueBuffer : PacketBuffer
+    {
+        private readonly Queue<Packet> Queue; // Packet queue
+
+        public QueueBuffer()
+        {
+            Queue = new Queue<Packet>();
+        }
+
+        /// <summary>
+        /// Add a packet to buffer.
+        /// </summary>
+        /// 
+        /// <param name="Packet"> The packet to add. </param>
+        /// <param name="Priority"> Should always be zero because there's just one queue. </param>
+        /// 
+        /// <exception cref="ArgumentException"> If priority is not zero since there's just one queue. </exception>
+        public override void Enqueue(Packet Packet, int Priority = 0)
+        {
+            if (Priority != 0)
+                throw new ArgumentException("Leaky bucket controller doesn't have priority.");
+
+            lock (Queue)
+            {
+                Queue.Enqueue(Packet);
+            }
+        }
+
+        /// <summary>
+        /// Get next packet without removing it.
+        /// </summary>
+        /// 
+        /// <remarks>
+        /// It will return null if the buffer is empty instead of throwing an exception.
+        /// </remarks>
+        /// 
+        /// <returns> Next packet if buffer is not empty, or null otherwise. </returns>
+        public override Packet Peek()
+        {
+            lock (Queue)
+            {
+                try
+                {
+                    return Queue.Peek();
+                }
+                catch (InvalidOperationException)
+                {
+                    return null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get next packet and remove it.
+        /// </summary>
+        /// 
+        /// <remarks>
+        /// It will return null if the buffer is empty instead of throwing an exception.
+        /// </remarks>
+        /// 
+        /// <returns> Next packet if buffer is not empty, or null otherwise. </returns>
+        public override Packet Dequeue()
+        {
+            lock (Queue)
+            {
+                try
+                {
+                    return Queue.Dequeue();
+                }
+                catch (InvalidOperationException)
+                {
+                    return null;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// This defines a priority buffer that dequeue the highest priority packet first.
+    /// </summary>
+    public class PriorityBuffer : PacketBuffer
+    {
+        private readonly PacketBuffer[] Buffers; // List of buffers of each priority
+        public readonly int NBuffers; // Number of buffers
+
+        /// <summary>
+        /// Construct priority buffer with a list of sub-buffers.
+        /// </summary>
+        /// 
+        /// <param name="Buffers"> List of buffers for each priority. Low index means higher priority. </param>
+        public PriorityBuffer(PacketBuffer[] Buffers)
+        {
+            this.Buffers = Buffers;
+            NBuffers = Buffers.Length;
+        }
+
+        /// <summary>
+        /// Add a packet to buffer.
+        /// </summary>
+        /// 
+        /// <param name="Packet"> The packet to add. </param>
+        /// <param name="Priority"> Priority of packet. Lower number means higher priority. </param>
+        /// 
+        /// <exception cref="ArgumentOutOfRangeException"> If priority is out of range. </exception>
+        public override void Enqueue(Packet Packet, int Priority)
+        {
+            if (Priority < 0 || Priority >= NBuffers)
+                throw new ArgumentOutOfRangeException("Priority number is out of range");
+
+            Buffers[Priority].Enqueue(Packet, 0);
+        }
+
+        /// <summary>
+        /// Get next packet without removing it.
+        /// </summary>
+        /// 
+        /// <remarks>
+        /// It will return null if the buffer is empty instead of throwing an exception.
+        /// </remarks>
+        /// 
+        /// <returns> Next packet if buffer is not empty, or null otherwise. </returns>
+        public override Packet Peek()
+        {
+            for (int i = 0; i < NBuffers; i++)
+            {
+                Packet Next = Buffers[i].Peek();
+
+                if (Next != null)
+                    return Next;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Get next packet and remove it.
+        /// </summary>
+        /// 
+        /// <remarks>
+        /// It will return null if the buffer is empty instead of throwing an exception.
+        /// </remarks>
+        /// 
+        /// <returns> Next packet if buffer is not empty, or null otherwise. </returns>
+        public override Packet Dequeue()
+        {
+            for (int i = 0; i < NBuffers; i++)
+            {
+                Packet next = Buffers[i].Dequeue();
+
+                if (next != null)
+                    return next;
+            }
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// This defines a bandwidth control buffer that controlls the bandwidth for each priority.
+    /// </summary>
+    public class BandwidthControlBuffer : PacketBuffer
+    {
+        private readonly PacketBuffer[] Buffers; // List of buffers for each priority
+        private readonly int[] BandwidthAllocations; // Bandwidth allocation for each priority
+        private readonly int NBuffers; // Number of buffers
+        private readonly int[] TokenBuckets; // Token bucket for each priority
+        private int MaximumToken; // Maximum token bucket size for each priority
+        private int CurrentBucket; // Current priority that is being sent
+        private Packet PacketCache; // Cache for last peeked packet.
+
+        /// <summary>
+        /// Construct a controller.
+        /// </summary>
+        /// 
+        /// <remarks>
+        /// If `BandwidthAllocation` is null, it will be set to all 1's.
+        /// </remarks>
+        /// 
+        /// <param name="Buffers"> List of buffers for each priority. </param>
+        /// <param name="BandwidthAllocation"> List of integers that represent the portion of bandwidth assigned to each priority. </param>
+        /// <param name="MaximumToken"> Maximum token bucket size. </param>
+        /// 
+        /// <exception cref="ArgumentException"> If length of `Buffers` and `BandwidthAllocation` is not equal. </exception>
+        /// <exception cref="ArgumentOutOfRangeException"> If maximum token bucket size is not positive. </exception>
+        public BandwidthControlBuffer(PacketBuffer[] Buffers, int[] BandwidthAllocation = null, int MaximumToken = 256)
+        {
+            // Default value for `BandwidthAllocation`
+            if (BandwidthAllocation == null)
+            {
+                BandwidthAllocation = new int[Buffers.Length];
+                for (int i = 0; i < BandwidthAllocation.Length; i++)
+                    BandwidthAllocation[i] = 1;
+            }
+
+            if (Buffers.Length != BandwidthAllocation.Length)
+                throw new ArgumentException("Number of bandwith assignment doesn't match number of Buffers");
+
+            if (MaximumToken <= 0)
+                throw new ArgumentOutOfRangeException("Maximum token should be greater than zero");
+
+            this.Buffers = Buffers;
+            this.BandwidthAllocations = BandwidthAllocation;
+            this.MaximumToken = MaximumToken;
+            NBuffers = Buffers.Length;
+            CurrentBucket = 0;
+            PacketCache = null;
+
+            TokenBuckets = new int[NBuffers];
+            for (int i = 0; i < NBuffers; i++)
+                TokenBuckets[i] = 0;
+        }
+
+        /// <summary>
+        /// Add `Multiple * BandwidthAllocation[i]` tokens to each token bucket.
+        /// </summary>
+        /// 
+        /// <param name="Multiple"> How many tokens to add. </param>
+        private void AddToken(int Multiple)
+        {
+            for (int i = 0; i < NBuffers; i++)
+            {
+                TokenBuckets[i] = Math.Min(TokenBuckets[i] + Multiple * BandwidthAllocations[i], MaximumToken);
+            }
+        }
+
+        /// <summary>
+        /// Find next bucket that have both packet and sufficient token.
+        /// If no bucket have both packet and sufficient token, find the bucket with packet but insufficient token.
+        /// </summary>
+        /// 
+        /// <remarks>
+        /// It changes `CurrentBucket` to next candidate.
+        /// </remarks>
+        /// 
+        /// <returns> true if all buffers are empty. </returns>
+        private bool NextBucket()
+        {
+            // Find the bucket with packet and sufficient token
+            int Previous = CurrentBucket;
+            do
+            {
+                CurrentBucket = CurrentBucket + 1;
+                CurrentBucket = CurrentBucket >= NBuffers ? 0 : CurrentBucket;
+            } while (CurrentBucket != Previous &&
+                (TokenBuckets[CurrentBucket] < 0 || Buffers[CurrentBucket].Peek() == null));
+
+            if (CurrentBucket != Previous)
+            {
+                // Found the packet
+                return false;
+            }
+            else
+            {
+                // Find the bucket with packet
+                for (CurrentBucket = 0; CurrentBucket < NBuffers; CurrentBucket++)
+                    if (Buffers[CurrentBucket].Peek() != null)
+                        return false;
+
+                // Didn't find anything
+                CurrentBucket = 0;
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Add a packet to buffer.
+        /// </summary>
+        /// 
+        /// <param name="Packet"> The packet to add. </param>
+        /// <param name="Priority"> Priority of packet. </param>
+        /// 
+        /// <exception cref="ArgumentOutOfRangeException"> If priority is out of range. </exception>
+        public override void Enqueue(Packet Packet, int Priority)
+        {
+            if (Priority < 0 || Priority >= NBuffers)
+                throw new ArgumentOutOfRangeException("Priority number is out of range");
+
+            Buffers[Priority].Enqueue(Packet, 0);
+        }
+
+        /// <summary>
+        /// Get next packet without removing it.
+        /// </summary>
+        /// 
+        /// <remarks>
+        /// It will return null if the buffer is empty instead of throwing an exception.
+        /// </remarks>
+        /// 
+        /// <returns> Next packet if buffer is not empty, or null otherwise. </returns>
+        public override Packet Peek()
+        {
+            if (PacketCache == null)
+                PacketCache = Dequeue(); // Store next packet into cache so it can be removed on next call of dequeue
+
+            return PacketCache;
+        }
+
+        /// <summary>
+        /// Get next packet and remove it.
+        /// </summary>
+        /// 
+        /// <remarks>
+        /// It will return null if the buffer is empty instead of throwing an exception.
+        /// </remarks>
+        /// 
+        /// <returns> Next packet if buffer is not empty, or null otherwise. </returns>
+        public override Packet Dequeue()
+        {
+            // Use the packet stored in cache if available
+            if (PacketCache != null)
+            {
+                Packet LastPacket = PacketCache;
+                PacketCache = null;
+                return LastPacket;
+            }
+
+            // Find next packet
+            if (TokenBuckets[CurrentBucket] < 0 || Buffers[CurrentBucket].Peek() == null)
+                if (NextBucket())
+                    return null; // Can't find any packet
+
+            // Update token bucket
+            Packet Next = Buffers[CurrentBucket].Dequeue();
+            TokenBuckets[CurrentBucket] -= Next.GetLength();
+
+            // Refill token bucket if it is not enough
+            if (TokenBuckets[CurrentBucket] < 0)
+            {
+                AddToken(1 + (-TokenBuckets[CurrentBucket]) / BandwidthAllocations[CurrentBucket]);
+
+                // Switch to the buffer of next prioirity
+                CurrentBucket = CurrentBucket + 1;
+                CurrentBucket = CurrentBucket >= NBuffers ? 0 : CurrentBucket;
+            }
+            return Next;
+        }
+    }
+
+    /// <summary>
+    /// This defines a generic controller.
+    /// The order of absolute priority is EMERGENT > HIGH == MEDIUM == LOW > LOWEST,
+    /// and the bandwidth allocation of HIGH : MEDIUM : LOW is 3 : 2 : 1.
+    /// </summary>
+    public class GenericController : PacketBuffer
+    {
+        public enum Priority { EMERGENT, HIGH, MEDIUM, LOW, LOWEST };
+        public readonly QueueBuffer[] Buffers;
+        public readonly PriorityBuffer PriorityBuffer;
+        public readonly BandwidthControlBuffer BandwidthBuffer;
+
+        /// <summary>
+        /// Constrict a generic Controller.
+        /// </summary>
+        public GenericController()
+        {
+            Buffers = new QueueBuffer[5];
+            for (int i = 0; i < 5; i++)
+                Buffers[i] = new QueueBuffer();
+
+            PacketBuffer[] BandwidthSubcontrollers = { Buffers[1], Buffers[2], Buffers[3] };
+            int[] BandwidthAllocation = { 3, 2, 1 };
+            BandwidthBuffer = new BandwidthControlBuffer(BandwidthSubcontrollers, BandwidthAllocation);
+
+            PacketBuffer[] PrioritySubcontrollers = { Buffers[0], BandwidthBuffer, Buffers[4] };
+            PriorityBuffer = new PriorityBuffer(PrioritySubcontrollers);
+        }
+
+        /// <summary>
+        /// Add a packet to buffer.
+        /// </summary>
+        /// 
+        /// <param name="Packet"> The packet to add. </param>
+        /// <param name="Priority"> Priority of packet. </param>
+        /// 
+        /// <exception cref="ArgumentOutOfRangeException"> If priority is out of range. </exception>
+        public override void Enqueue(Packet Packet, int Priority)
+        {
+            if (Priority < 0 || Priority >= 5)
+                throw new ArgumentOutOfRangeException("Priority number is out of range");
+
+            Buffers[Priority].Enqueue(Packet);
+        }
+
+        /// <summary>
+        /// Add a packet to buffer.
+        /// </summary>
+        /// 
+        /// <param name="Packet"> The packet to add. </param>
+        /// <param name="Priority"> Priority of packet. </param>
+        /// 
+        /// <exception cref="ArgumentOutOfRangeException"> If priority is out of range. </exception>
+        public void Enqueue(Packet Packet, Priority priority = Priority.MEDIUM)
+        {
+            if (priority < 0 || (int)priority >= 5)
+                throw new ArgumentOutOfRangeException("Priority number is out of range");
+
+            Buffers[(int)priority].Enqueue(Packet);
+        }
+
+        /// <summary>
+        /// Get next packet without removing it.
+        /// </summary>
+        /// 
+        /// <remarks>
+        /// It will return null if the buffer is empty instead of throwing an exception.
+        /// </remarks>
+        /// 
+        /// <returns> Next packet if buffer is not empty, or null otherwise. </returns>
+        public override Packet Peek()
+        {
+            return PriorityBuffer.Peek();
+        }
+
+
+        /// <summary>
+        /// Get next packet and remove it.
+        /// </summary>
+        /// 
+        /// <remarks>
+        /// It will return null if the buffer is empty instead of throwing an exception.
+        /// </remarks>
+        /// 
+        /// <returns> Next packet if buffer is not empty, or null otherwise. </returns>
+        public override Packet Dequeue()
+        {
+            return PriorityBuffer.Dequeue();
+        }
+    }
+}

--- a/Communications/PacketBuffer.cs
+++ b/Communications/PacketBuffer.cs
@@ -311,6 +311,8 @@ namespace Scarlet.Communications
     /// </summary>
     public class GenericController : PacketBuffer
     {
+        public static readonly int N_PRIORITIES = 5;
+
         public readonly QueueBuffer[] Buffers;
         public readonly PriorityBuffer PriorityBuffer;
         public readonly BandwidthControlBuffer BandwidthBuffer;
@@ -318,8 +320,8 @@ namespace Scarlet.Communications
         /// <summary> Construct a generic Controller. </summary>
         public GenericController()
         {
-            this.Buffers = new QueueBuffer[5];
-            for (int i = 0; i < 5; i++) { this.Buffers[i] = new QueueBuffer(); }
+            this.Buffers = new QueueBuffer[N_PRIORITIES];
+            for (int i = 0; i < N_PRIORITIES; i++) { this.Buffers[i] = new QueueBuffer(); }
 
             PacketBuffer[] BandwidthSubcontrollers = { this.Buffers[1], this.Buffers[2], this.Buffers[3] };
             int[] BandwidthAllocation = { 3, 2, 1 };
@@ -337,7 +339,7 @@ namespace Scarlet.Communications
         /// <exception cref="ArgumentOutOfRangeException"> If priority is out of range. </exception>
         public override void Enqueue(Packet Packet, int Priority)
         {
-            if (Priority < 0 || Priority >= 5) { throw new ArgumentOutOfRangeException("Priority number is out of range"); }
+            if (Priority < 0 || Priority >= N_PRIORITIES) { throw new ArgumentOutOfRangeException("Priority number is out of range"); }
             this.Buffers[Priority].Enqueue(Packet);
         }
 
@@ -349,7 +351,7 @@ namespace Scarlet.Communications
         /// <exception cref="ArgumentOutOfRangeException"> If priority is out of range. </exception>
         public void Enqueue(Packet Packet, PacketPriority Priority = PacketPriority.MEDIUM)
         {
-            if (Priority < 0 || (int)Priority >= 5) { throw new ArgumentOutOfRangeException("Priority number is out of range"); }
+            if (Priority < 0 || (int)Priority >= N_PRIORITIES) { throw new ArgumentOutOfRangeException("Priority number is out of range"); }
             this.Buffers[(int)Priority].Enqueue(Packet);
         }
 

--- a/Communications/PacketBuffer.cs
+++ b/Communications/PacketBuffer.cs
@@ -4,9 +4,7 @@ using Scarlet.Communications;
 
 namespace Scarlet.Communications
 {
-    /// <summary>
-    /// This defines the interface of packet buffer.
-    /// </summary>
+    /// <summary> This defines the interface of packet buffer. </summary>
     public abstract class PacketBuffer
     {
         /// <summary>
@@ -17,9 +15,7 @@ namespace Scarlet.Communications
         /// <param name="Priority"> Priority of packet. </param>
         public abstract void Enqueue(Packet Packet, int Priority);
 
-        /// <summary>
-        /// Get next packet without removing it.
-        /// </summary>
+        /// <summary> Get next packet without removing it. </summary>
         /// 
         /// <remarks>
         /// It will return null if the buffer is empty instead of throwing an exception.
@@ -28,9 +24,7 @@ namespace Scarlet.Communications
         /// <returns> Next packet if buffer is not empty, or null otherwise. </returns>
         public abstract Packet Peek();
 
-        /// <summary>
-        /// Get next packet and remove it.
-        /// </summary>
+        /// <summary> Get next packet and remove it. </summary>
         /// 
         /// <remarks>
         /// It will return null if the buffer is empty instead of throwing an exception.
@@ -39,14 +33,10 @@ namespace Scarlet.Communications
         /// <returns> Next packet if buffer is not empty, or null otherwise. </returns>
         public abstract Packet Dequeue();
 
-        /// <summary>
-        /// Get the total number of packets in the buffer.
-        /// </summary>
+        /// <summary>  Get the total number of packets in the buffer.  </summary>
         public abstract int Count { get; }
 
-        /// <summary>
-        /// Return whether the buffer is empty
-        /// </summary>
+        /// <summary> Return whether the buffer is empty </summary>
         /// <returns> true if buffer is empty, false otherwise. </returns>
         public bool IsEmpty()
         {
@@ -55,7 +45,7 @@ namespace Scarlet.Communications
     }
 
     /// <summary>
-    /// This class is a basic packet buffer. It is just a queue with thread safty guarantee.
+    /// This class is a basic packet buffer. It is just a queue with thread safety guarantee.
     /// </summary>
     public class QueueBuffer : PacketBuffer
     {
@@ -66,9 +56,7 @@ namespace Scarlet.Communications
             Queue = new Queue<Packet>();
         }
 
-        /// <summary>
-        /// Add a packet to buffer.
-        /// </summary>
+        /// <summary>  Add a packet to buffer. </summary>
         /// 
         /// <param name="Packet"> The packet to add. </param>
         /// <param name="Priority"> Should always be zero because there's just one queue. </param>
@@ -76,18 +64,12 @@ namespace Scarlet.Communications
         /// <exception cref="ArgumentException"> If priority is not zero since there's just one queue. </exception>
         public override void Enqueue(Packet Packet, int Priority = 0)
         {
-            if (Priority != 0)
-                throw new ArgumentException("Leaky bucket controller doesn't have priority.");
+            if (Priority != 0) { throw new ArgumentException("Leaky bucket controller doesn't have priority."); }
 
-            lock (Queue)
-            {
-                Queue.Enqueue(Packet);
-            }
+            lock (Queue) { Queue.Enqueue(Packet); }
         }
 
-        /// <summary>
-        /// Get next packet without removing it.
-        /// </summary>
+        /// <summary> Get next packet without removing it. </summary>
         /// 
         /// <remarks>
         /// It will return null if the buffer is empty instead of throwing an exception.
@@ -109,9 +91,7 @@ namespace Scarlet.Communications
             }
         }
 
-        /// <summary>
-        /// Get next packet and remove it.
-        /// </summary>
+        /// <summary> Get next packet and remove it. </summary>
         /// 
         /// <remarks>
         /// It will return null if the buffer is empty instead of throwing an exception.
@@ -133,17 +113,12 @@ namespace Scarlet.Communications
             }
         }
 
-        /// <summary>
-        /// Get the total number of packets in the buffer.
-        /// </summary>
+        /// <summary> Get the total number of packets in the buffer. </summary>
         public override int Count
         {
             get
             {
-                lock (Queue)
-                {
-                    return Queue.Count;
-                }
+                lock (Queue) { return Queue.Count; }
             }
         }
     }
@@ -156,20 +131,16 @@ namespace Scarlet.Communications
         private readonly PacketBuffer[] Buffers; // List of buffers of each priority
         public readonly int NBuffers; // Number of buffers
 
-        /// <summary>
-        /// Construct priority buffer with a list of sub-buffers.
-        /// </summary>
+        /// <summary> Construct priority buffer with a list of sub-buffers. </summary>
         /// 
         /// <param name="Buffers"> List of buffers for each priority. Low index means higher priority. </param>
         public PriorityBuffer(PacketBuffer[] Buffers)
         {
             this.Buffers = Buffers;
-            NBuffers = Buffers.Length;
+            this.NBuffers = Buffers.Length;
         }
 
-        /// <summary>
-        /// Add a packet to buffer.
-        /// </summary>
+        /// <summary> Add a packet to buffer. </summary>
         /// 
         /// <param name="Packet"> The packet to add. </param>
         /// <param name="Priority"> Priority of packet. Lower number means higher priority. </param>
@@ -177,15 +148,12 @@ namespace Scarlet.Communications
         /// <exception cref="ArgumentOutOfRangeException"> If priority is out of range. </exception>
         public override void Enqueue(Packet Packet, int Priority)
         {
-            if (Priority < 0 || Priority >= NBuffers)
-                throw new ArgumentOutOfRangeException("Priority number is out of range");
+            if (Priority < 0 || Priority >= NBuffers) { throw new ArgumentOutOfRangeException("Priority number is out of range"); }
 
             Buffers[Priority].Enqueue(Packet, 0);
         }
 
-        /// <summary>
-        /// Get next packet without removing it.
-        /// </summary>
+        /// <summary> Get next packet without removing it. </summary>
         /// 
         /// <remarks>
         /// It will return null if the buffer is empty instead of throwing an exception.
@@ -198,15 +166,12 @@ namespace Scarlet.Communications
             {
                 Packet Next = Buffers[i].Peek();
 
-                if (Next != null)
-                    return Next;
+                if (Next != null) { return Next; }
             }
             return null;
         }
 
-        /// <summary>
-        /// Get next packet and remove it.
-        /// </summary>
+        /// <summary> Get next packet and remove it. </summary>
         /// 
         /// <remarks>
         /// It will return null if the buffer is empty instead of throwing an exception.
@@ -219,15 +184,12 @@ namespace Scarlet.Communications
             {
                 Packet next = Buffers[i].Dequeue();
 
-                if (next != null)
-                    return next;
+                if (next != null) { return next; }
             }
             return null;
         }
 
-        /// <summary>
-        /// Get the total number of packets in the buffer.
-        /// </summary>
+        /// <summary> Get the total number of packets in the buffer. </summary>
         public override int Count
         {
             get
@@ -235,6 +197,7 @@ namespace Scarlet.Communications
                 int Sum = 0;
                 foreach (PacketBuffer Buffer in Buffers)
                     Sum += Buffer.Count;
+
                 return Sum;
             }
         }
@@ -253,9 +216,7 @@ namespace Scarlet.Communications
         private int CurrentBucket; // Current priority that is being sent
         private Packet PacketCache; // Cache for last peeked packet.
 
-        /// <summary>
-        /// Construct a controller.
-        /// </summary>
+        /// <summary> Construct a controller. </summary>
         /// 
         /// <remarks>
         /// If `BandwidthAllocation` is null, it will be set to all 1's.
@@ -286,9 +247,9 @@ namespace Scarlet.Communications
             this.Buffers = Buffers;
             this.BandwidthAllocations = BandwidthAllocation;
             this.MaximumToken = MaximumToken;
-            NBuffers = Buffers.Length;
-            CurrentBucket = 0;
-            PacketCache = null;
+            this.NBuffers = Buffers.Length;
+            this.CurrentBucket = 0;
+            this.PacketCache = null;
 
             TokenBuckets = new int[NBuffers];
             for (int i = 0; i < NBuffers; i++)
@@ -303,9 +264,7 @@ namespace Scarlet.Communications
         private void AddToken(int Multiple)
         {
             for (int i = 0; i < NBuffers; i++)
-            {
                 TokenBuckets[i] = Math.Min(TokenBuckets[i] + Multiple * BandwidthAllocations[i], MaximumToken);
-            }
         }
 
         /// <summary>
@@ -313,9 +272,7 @@ namespace Scarlet.Communications
         /// If no bucket have both packet and sufficient token, find the bucket with packet but insufficient token.
         /// </summary>
         /// 
-        /// <remarks>
-        /// It changes `CurrentBucket` to next candidate.
-        /// </remarks>
+        /// <remarks> It changes `CurrentBucket` to next candidate. </remarks>
         /// 
         /// <returns> true if all buffers are empty. </returns>
         private bool NextBucket()
@@ -329,11 +286,7 @@ namespace Scarlet.Communications
             } while (CurrentBucket != Previous &&
                 (TokenBuckets[CurrentBucket] < 0 || Buffers[CurrentBucket].Peek() == null));
 
-            if (CurrentBucket != Previous)
-            {
-                // Found the packet
-                return false;
-            }
+            if (CurrentBucket != Previous) { return false; } // Found the packet
             else
             {
                 // Find the bucket with packet
@@ -347,9 +300,7 @@ namespace Scarlet.Communications
             }
         }
 
-        /// <summary>
-        /// Add a packet to buffer.
-        /// </summary>
+        /// <summary> Add a packet to buffer. </summary>
         /// 
         /// <param name="Packet"> The packet to add. </param>
         /// <param name="Priority"> Priority of packet. </param>
@@ -363,9 +314,7 @@ namespace Scarlet.Communications
             Buffers[Priority].Enqueue(Packet, 0);
         }
 
-        /// <summary>
-        /// Get next packet without removing it.
-        /// </summary>
+        /// <summary> Get next packet without removing it. </summary>
         /// 
         /// <remarks>
         /// It will return null if the buffer is empty instead of throwing an exception.
@@ -380,9 +329,7 @@ namespace Scarlet.Communications
             return PacketCache;
         }
 
-        /// <summary>
-        /// Get next packet and remove it.
-        /// </summary>
+        /// <summary> Get next packet and remove it. </summary>
         /// 
         /// <remarks>
         /// It will return null if the buffer is empty instead of throwing an exception.
@@ -420,9 +367,7 @@ namespace Scarlet.Communications
             return Next;
         }
 
-        /// <summary>
-        /// Get the total number of packets in the buffer.
-        /// </summary>
+        /// <summary> Get the total number of packets in the buffer. </summary>
         public override int Count
         {
             get
@@ -446,9 +391,7 @@ namespace Scarlet.Communications
         public readonly PriorityBuffer PriorityBuffer;
         public readonly BandwidthControlBuffer BandwidthBuffer;
 
-        /// <summary>
-        /// Constrict a generic Controller.
-        /// </summary>
+        /// <summary> Constrict a generic Controller. </summary>
         public GenericController()
         {
             Buffers = new QueueBuffer[5];
@@ -463,9 +406,7 @@ namespace Scarlet.Communications
             PriorityBuffer = new PriorityBuffer(PrioritySubcontrollers);
         }
 
-        /// <summary>
-        /// Add a packet to buffer.
-        /// </summary>
+        /// <summary> Add a packet to buffer. </summary>
         /// 
         /// <param name="Packet"> The packet to add. </param>
         /// <param name="Priority"> Priority of packet. </param>
@@ -479,9 +420,7 @@ namespace Scarlet.Communications
             Buffers[Priority].Enqueue(Packet);
         }
 
-        /// <summary>
-        /// Add a packet to buffer.
-        /// </summary>
+        /// <summary> Add a packet to buffer. </summary>
         /// 
         /// <param name="Packet"> The packet to add. </param>
         /// <param name="Priority"> Priority of packet. </param>
@@ -495,9 +434,7 @@ namespace Scarlet.Communications
             Buffers[(int)priority].Enqueue(Packet);
         }
 
-        /// <summary>
-        /// Get next packet without removing it.
-        /// </summary>
+        /// <summary> Get next packet without removing it. </summary>
         /// 
         /// <remarks>
         /// It will return null if the buffer is empty instead of throwing an exception.
@@ -510,9 +447,7 @@ namespace Scarlet.Communications
         }
 
 
-        /// <summary>
-        /// Get next packet and remove it.
-        /// </summary>
+        /// <summary> Get next packet and remove it. </summary>
         /// 
         /// <remarks>
         /// It will return null if the buffer is empty instead of throwing an exception.
@@ -524,9 +459,7 @@ namespace Scarlet.Communications
             return PriorityBuffer.Dequeue();
         }
 
-        /// <summary>
-        /// Get the total number of packets in the buffer.
-        /// </summary>
+        /// <summary> Get the total number of packets in the buffer. </summary>
         public override int Count
         {
             get

--- a/Communications/PacketBuffer.cs
+++ b/Communications/PacketBuffer.cs
@@ -43,6 +43,15 @@ namespace Scarlet.Communications
         /// Get the total number of packets in the buffer.
         /// </summary>
         public abstract int Count { get; }
+
+        /// <summary>
+        /// Return whether the buffer is empty
+        /// </summary>
+        /// <returns> true if buffer is empty, false otherwise. </returns>
+        public bool IsEmpty()
+        {
+            return Peek() != null;
+        }
     }
 
     /// <summary>
@@ -131,7 +140,10 @@ namespace Scarlet.Communications
         {
             get
             {
-                return Queue.Count;
+                lock (Queue)
+                {
+                    return Queue.Count;
+                }
             }
         }
     }

--- a/Communications/PacketBuffer.cs
+++ b/Communications/PacketBuffer.cs
@@ -38,6 +38,11 @@ namespace Scarlet.Communications
         /// 
         /// <returns> Next packet if buffer is not empty, or null otherwise. </returns>
         public abstract Packet Dequeue();
+
+        /// <summary>
+        /// Get the total number of packets in the buffer.
+        /// </summary>
+        public abstract int Count { get; }
     }
 
     /// <summary>
@@ -118,6 +123,17 @@ namespace Scarlet.Communications
                 }
             }
         }
+
+        /// <summary>
+        /// Get the total number of packets in the buffer.
+        /// </summary>
+        public override int Count
+        {
+            get
+            {
+                return Queue.Count;
+            }
+        }
     }
 
     /// <summary>
@@ -195,6 +211,20 @@ namespace Scarlet.Communications
                     return next;
             }
             return null;
+        }
+
+        /// <summary>
+        /// Get the total number of packets in the buffer.
+        /// </summary>
+        public override int Count
+        {
+            get
+            {
+                int Sum = 0;
+                foreach (PacketBuffer Buffer in Buffers)
+                    Sum += Buffer.Count;
+                return Sum;
+            }
         }
     }
 
@@ -377,6 +407,20 @@ namespace Scarlet.Communications
             }
             return Next;
         }
+
+        /// <summary>
+        /// Get the total number of packets in the buffer.
+        /// </summary>
+        public override int Count
+        {
+            get
+            {
+                int Sum = 0;
+                foreach (PacketBuffer Buffer in Buffers)
+                    Sum += Buffer.Count;
+                return Sum;
+            }
+        }
     }
 
     /// <summary>
@@ -467,6 +511,17 @@ namespace Scarlet.Communications
         public override Packet Dequeue()
         {
             return PriorityBuffer.Dequeue();
+        }
+
+        /// <summary>
+        /// Get the total number of packets in the buffer.
+        /// </summary>
+        public override int Count
+        {
+            get
+            {
+                return PriorityBuffer.Count;
+            }
         }
     }
 }

--- a/Communications/Server.cs
+++ b/Communications/Server.cs
@@ -430,10 +430,12 @@ namespace Scarlet.Communications
             while (!Stopping)
             {
                 Packet CurrentPacket = ReceiveQueue.Dequeue();
-                CurrentPacket = (Packet) CurrentPacket.Clone();
 
                 if (CurrentPacket != null)
+                {
+                    CurrentPacket = (Packet)CurrentPacket.Clone();
                     ProcessOnePacket(CurrentPacket);
+                }
                 Thread.Sleep(OperationPeriod);
             }
         }

--- a/Communications/Server.cs
+++ b/Communications/Server.cs
@@ -40,8 +40,8 @@ namespace Scarlet.Communications
         public static List<Packet> PacketsReceived, PacketsSent;
 
         // Packet Priority
-        public static bool PriorityQueueEnabled;
-        public static PacketPriority DefaultPriority;
+        public static bool PriorityQueueEnabled { get; private set; }
+        public static PacketPriority DefaultPriority { get; private set; }
 
         /// <summary>
         /// Prepares the server for use, and starts listening for clients.

--- a/Communications/Server.cs
+++ b/Communications/Server.cs
@@ -477,8 +477,7 @@ namespace Scarlet.Communications
             else
             {
                 // Use default priority if needed
-                if (Priority == PacketPriority.USE_DEFAULT)
-                    Priority = DefaultPriority;
+                if (Priority == PacketPriority.USE_DEFAULT) { Priority = DefaultPriority; }
 
                 // Add to queue
                 SendQueues[Packet.Endpoint].Enqueue(Packet, (int) Priority);

--- a/Communications/Server.cs
+++ b/Communications/Server.cs
@@ -50,7 +50,8 @@ namespace Scarlet.Communications
         /// <param name="PortUDP">The port to listen on for clients communicating via UDP.</param>
         /// <param name="ReceiveBufferSize">The size, in bytes, of the receive data buffers. Increase this if your packets are longer than the default.</param>
         /// <param name="OperationPeriod">The time, in ms, between network operations. If you are sending/receiving a lot of packets, and notice delays, lower this.</param>
-        public static void Start(int PortTCP, int PortUDP, bool UsePriorityQueue = true, int ReceiveBufferSize = 64, int OperationPeriod = 20)
+        /// <param name="UsePriorityQueue"> If it is ture, packet priority control will be enabled. </param>
+        public static void Start(int PortTCP, int PortUDP, int ReceiveBufferSize = 64, int OperationPeriod = 20, bool UsePriorityQueue = false)
         {
             Server.ReceiveBufferSize = ReceiveBufferSize;
             Server.OperationPeriod = OperationPeriod;
@@ -83,8 +84,7 @@ namespace Scarlet.Communications
                 WatchdogManager.Start(false);
                 WatchdogManager.ConnectionChanged += WatchdogStatusUpdate;
             }
-            else
-                Log.Output(Log.Severity.WARNING, Log.Source.NETWORK, "Attempted to start Server when already started.");
+            else { Log.Output(Log.Severity.WARNING, Log.Source.NETWORK, "Attempted to start Server when already started."); }
         }
 
         /// <summary>
@@ -155,7 +155,7 @@ namespace Scarlet.Communications
         /// </summary>
         /// 
         /// <param name="ClientName"> Name of the client. </param>
-        private static void CreatBufferIfClientIsNew(string ClientName)
+        private static void CreateBufferIfClientIsNew(string ClientName)
         {
             lock (SendQueues)
             {
@@ -222,7 +222,7 @@ namespace Scarlet.Communications
                         }
 
                         // Create buffer for the client
-                        CreatBufferIfClientIsNew(ClientName);
+                        CreateBufferIfClientIsNew(ClientName);
                     }
                     else { Log.Output(Log.Severity.WARNING, Log.Source.NETWORK, "Invalid TCP client name received. Dropping connection."); }
                 }
@@ -258,8 +258,7 @@ namespace Scarlet.Communications
                         Packet ReceivedPack = new Packet(new Message(Data), false, ClientName);
                         ReceiveQueue.Enqueue(ReceivedPack);
 
-                        if (StorePackets)
-                            PacketsReceived.Add(ReceivedPack);
+                        if (StorePackets) { PacketsReceived.Add(ReceivedPack); }
                     }
                     else { Log.Output(Log.Severity.WARNING, Log.Source.NETWORK, "Data received from client was too short. Discarding."); }
                 }
@@ -360,7 +359,7 @@ namespace Scarlet.Communications
                         }
 
                         // Create buffer for the client
-                        CreatBufferIfClientIsNew(ClientName);
+                        CreateBufferIfClientIsNew(ClientName);
                     }
                     else { Log.Output(Log.Severity.WARNING, Log.Source.NETWORK, "UDP Client sent invalid name upon connecting."); }
                 }
@@ -369,8 +368,7 @@ namespace Scarlet.Communications
                     Packet ReceivedPack = new Packet(new Message(Data), false, ClientName);
                     ReceiveQueue.Enqueue(ReceivedPack);
 
-                    if (StorePackets)
-                        PacketsReceived.Add(ReceivedPack);
+                    if (StorePackets) { PacketsReceived.Add(ReceivedPack); }
                 }
             }
             Listener.BeginReceive(HandleUDPData, Listener);

--- a/Scarlet.csproj
+++ b/Scarlet.csproj
@@ -49,6 +49,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Communications\PacketBuffer.cs" />
     <Compile Include="Communications\WatchdogManager.cs" />
     <Compile Include="Communications\PacketHandler.cs" />
     <Compile Include="Communications\Client.cs" />

--- a/Scarlet.sln
+++ b/Scarlet.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27004.2009
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Scarlet", "Scarlet.csproj", "{EB8D6FE6-E3DD-4049-89A2-F636C6D70477}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTest", "UnitTest\UnitTest.csproj", "{275370AF-621E-49B7-965F-88BDC665B287}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{EB8D6FE6-E3DD-4049-89A2-F636C6D70477}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EB8D6FE6-E3DD-4049-89A2-F636C6D70477}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EB8D6FE6-E3DD-4049-89A2-F636C6D70477}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EB8D6FE6-E3DD-4049-89A2-F636C6D70477}.Release|Any CPU.Build.0 = Release|Any CPU
+		{275370AF-621E-49B7-965F-88BDC665B287}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{275370AF-621E-49B7-965F-88BDC665B287}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{275370AF-621E-49B7-965F-88BDC665B287}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{275370AF-621E-49B7-965F-88BDC665B287}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {62764D73-4DC5-42B1-B590-4EB3A4D06335}
+	EndGlobalSection
+EndGlobal

--- a/UnitTest/Properties/AssemblyInfo.cs
+++ b/UnitTest/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("UnitTest")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("UnitTest")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("275370af-621e-49b7-965f-88bdc665b287")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/UnitTest/TestClientAndServer.cs
+++ b/UnitTest/TestClientAndServer.cs
@@ -12,9 +12,9 @@ namespace UnitTest
 
         private void InitializeConnection()
         {
-            Server.Start(2000, 2001);
+            Server.Start(2000, 2001, UsePriorityQueue: true);
             System.Threading.Thread.Sleep(500);
-            Client.Start("127.0.0.1", 2000, 2001, "TestClient");
+            Client.Start("127.0.0.1", 2000, 2001, "TestClient", UsePriorityQueue: true);
             System.Threading.Thread.Sleep(500);
         }
 

--- a/UnitTest/TestClientAndServer.cs
+++ b/UnitTest/TestClientAndServer.cs
@@ -8,13 +8,13 @@ namespace UnitTest
     [TestClass]
     public class UnitTestClientAndServer
     {
-        private static String ReceivedMessage;
+        private static String ReceivedMessage, ReceivedMessage2;
 
         private void InitializeConnection()
         {
             Server.Start(2000, 2001);
             System.Threading.Thread.Sleep(500);
-            Client.Start("127.0.0.1", 2000, 2001, "MyClient");
+            Client.Start("127.0.0.1", 2000, 2001, "TestClient");
             System.Threading.Thread.Sleep(500);
         }
 
@@ -23,18 +23,32 @@ namespace UnitTest
             ReceivedMessage = UtilData.ToString(Packet.Data.Payload);
         }
 
+        public void MessageHandler2(Packet Packet)
+        {
+            ReceivedMessage2 = UtilData.ToString(Packet.Data.Payload);
+        }
+
         [TestMethod]
         public void BasicTest()
         {
-            String TestText = "Hello, World!";
-            Byte ChannelID = 0xcd;
+            String TestText1 = "Hello, World!";
+            String TestText2 = "hello, world";
+            Byte ChannelID1 = 0xcd;
+            Byte ChannelID2 = 0xcf;
 
             InitializeConnection();
-            Parse.SetParseHandler(ChannelID, MessageHandler);
-            Packet MyPack = new Packet(new Message(ChannelID, UtilData.ToBytes(TestText)), false);
-            Client.Send(MyPack);
+            Parse.SetParseHandler(ChannelID1, MessageHandler);
+            Parse.SetParseHandler(ChannelID2, MessageHandler2);
+
+            Packet MyPack = new Packet(new Message(ChannelID1, UtilData.ToBytes(TestText1)), false);
+            Client.Send(MyPack, PacketPriority.LOWEST);
             System.Threading.Thread.Sleep(200);
-            Assert.AreEqual(TestText, ReceivedMessage);
+            Assert.AreEqual(TestText1, ReceivedMessage);
+
+            Packet MyPack2 = new Packet(new Message(ChannelID2, UtilData.ToBytes(TestText2)), false, "TestClient");
+            Server.Send(MyPack2);
+            System.Threading.Thread.Sleep(200);
+            Assert.AreEqual(TestText2, ReceivedMessage2);
         }
     }
 }

--- a/UnitTest/TestClientAndServer.cs
+++ b/UnitTest/TestClientAndServer.cs
@@ -18,6 +18,14 @@ namespace UnitTest
             System.Threading.Thread.Sleep(500);
         }
 
+        private void InitializeConnectionWithQueueBuffer()
+        {
+            Server.Start(2000, 2001, UsePriorityQueue: false);
+            System.Threading.Thread.Sleep(500);
+            Client.Start("127.0.0.1", 2000, 2001, "TestClient", UsePriorityQueue: false);
+            System.Threading.Thread.Sleep(500);
+        }
+
         public void MessageHandler(Packet Packet)
         {
             ReceivedMessage = UtilData.ToString(Packet.Data.Payload);
@@ -42,6 +50,53 @@ namespace UnitTest
 
             Packet MyPack = new Packet(new Message(ChannelID1, UtilData.ToBytes(TestText1)), false);
             Client.Send(MyPack, PacketPriority.LOWEST);
+            System.Threading.Thread.Sleep(200);
+            Assert.AreEqual(TestText1, ReceivedMessage);
+
+            Packet MyPack2 = new Packet(new Message(ChannelID2, UtilData.ToBytes(TestText2)), false, "TestClient");
+            Server.Send(MyPack2, PacketPriority.LOWEST);
+            System.Threading.Thread.Sleep(200);
+            Assert.AreEqual(TestText2, ReceivedMessage2);
+        }
+
+
+        [TestMethod]
+        public void BasicTestDefaultPriority()
+        {
+            String TestText1 = "Hello, World!";
+            String TestText2 = "hello, world";
+            Byte ChannelID1 = 0xcd;
+            Byte ChannelID2 = 0xcf;
+
+            InitializeConnection();
+            Parse.SetParseHandler(ChannelID1, MessageHandler);
+            Parse.SetParseHandler(ChannelID2, MessageHandler2);
+
+            Packet MyPack = new Packet(new Message(ChannelID1, UtilData.ToBytes(TestText1)), false);
+            Client.Send(MyPack);
+            System.Threading.Thread.Sleep(200);
+            Assert.AreEqual(TestText1, ReceivedMessage);
+
+            Packet MyPack2 = new Packet(new Message(ChannelID2, UtilData.ToBytes(TestText2)), false, "TestClient");
+            Server.Send(MyPack2);
+            System.Threading.Thread.Sleep(200);
+            Assert.AreEqual(TestText2, ReceivedMessage2);
+        }
+
+        [TestMethod]
+        public void BasicTestQueueBuffer()
+        {
+            String TestText1 = "Hello, World!";
+            String TestText2 = "hello, world";
+            Byte ChannelID1 = 0xcd;
+            Byte ChannelID2 = 0xcf;
+
+            InitializeConnectionWithQueueBuffer();
+            Parse.SetParseHandler(ChannelID1, MessageHandler);
+            Parse.SetParseHandler(ChannelID2, MessageHandler2);
+
+            Packet MyPack = new Packet(new Message(ChannelID1, UtilData.ToBytes(TestText1)), false);
+            Client.Send(MyPack);
             System.Threading.Thread.Sleep(200);
             Assert.AreEqual(TestText1, ReceivedMessage);
 

--- a/UnitTest/TestClientAndServer.cs
+++ b/UnitTest/TestClientAndServer.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Scarlet.Communications;
+using Scarlet.Utilities;
+
+namespace UnitTest
+{
+    [TestClass]
+    public class UnitTestClientAndServer
+    {
+        private static String ReceivedMessage;
+
+        private void InitializeConnection()
+        {
+            Server.Start(2000, 2001);
+            System.Threading.Thread.Sleep(500);
+            Client.Start("127.0.0.1", 2000, 2001, "MyClient");
+            System.Threading.Thread.Sleep(500);
+        }
+
+        public void MessageHandler(Packet Packet)
+        {
+            ReceivedMessage = UtilData.ToString(Packet.Data.Payload);
+        }
+
+        [TestMethod]
+        public void BasicTest()
+        {
+            String TestText = "Hello, World!";
+            Byte ChannelID = 0xcd;
+
+            InitializeConnection();
+            Parse.SetParseHandler(ChannelID, MessageHandler);
+            Packet MyPack = new Packet(new Message(ChannelID, UtilData.ToBytes(TestText)), false);
+            Client.Send(MyPack);
+            System.Threading.Thread.Sleep(200);
+            Assert.AreEqual(TestText, ReceivedMessage);
+        }
+    }
+}

--- a/UnitTest/TestPacketBuffer.cs
+++ b/UnitTest/TestPacketBuffer.cs
@@ -318,5 +318,21 @@ namespace UnitTest
             Assert.AreEqual(controller.Dequeue(), null);
             Assert.AreEqual(controller.Peek(), null);
         }
+
+        [TestMethod]
+        public void TestCount()
+        {
+            GenericController controller = new GenericController();
+            controller.Enqueue(NewPacket(10, 0), 0);
+            controller.Enqueue(NewPacket(10, 0), 0);
+            controller.Enqueue(NewPacket(10, 1), 1);
+            controller.Enqueue(NewPacket(10, 1), 1);
+            controller.Enqueue(NewPacket(10, 2), 2);
+            controller.Enqueue(NewPacket(10, 3), 3);
+            controller.Enqueue(NewPacket(10, 3), 3);
+            controller.Enqueue(NewPacket(10, 4), 4);
+
+            Assert.AreEqual(8, controller.Count);
+        }
     }
 }

--- a/UnitTest/TestPacketBuffer.cs
+++ b/UnitTest/TestPacketBuffer.cs
@@ -27,13 +27,13 @@ namespace UnitTest
 
         public static Packet NewPacket(int length, int priority)
         {
-
+            return new Packet(new Message((byte)priority, new byte[length]), false);
         }
 
         public static void AssertPacket(Packet p, int length, int priority)
         {
-            Assert.AreEqual(p.length, length);
-            Assert.AreEqual(p.priority, priority);
+            Assert.AreEqual(p.Data.Payload.Length, length);
+            Assert.AreEqual(p.Data.ID, priority);
         }
 
         [TestMethod]
@@ -44,7 +44,7 @@ namespace UnitTest
             Assert.AreEqual(controller.Peek(), null);
             Assert.AreEqual(controller.Dequeue(), null);
 
-            controller.Enqueue(new Packet(10, 0));
+            controller.Enqueue(NewPacket(10, 0));
             AssertPacket(controller.Peek(), 10, 0);
             AssertPacket(controller.Dequeue(), 10, 0);
             Assert.AreEqual(controller.Peek(), null);
@@ -57,7 +57,7 @@ namespace UnitTest
             QueueBuffer controller = new QueueBuffer();
             int capacity = 200000;
             for (int i = 0; i < capacity; i++)
-                controller.Enqueue(new Packet(10, 0));
+                controller.Enqueue(NewPacket(10, 0));
             controller.Peek();
             for (int i = 0; i < capacity; i++)
                 controller.Dequeue();
@@ -67,9 +67,9 @@ namespace UnitTest
         public void TestLeakyBucketOrder()
         {
             QueueBuffer controller = new QueueBuffer();
-            controller.Enqueue(new Packet(1, 0));
-            controller.Enqueue(new Packet(2, 0));
-            controller.Enqueue(new Packet(3, 0));
+            controller.Enqueue(NewPacket(1, 0));
+            controller.Enqueue(NewPacket(2, 0));
+            controller.Enqueue(NewPacket(3, 0));
             AssertPacket(controller.Dequeue(), 1, 0);
             AssertPacket(controller.Dequeue(), 2, 0);
             AssertPacket(controller.Dequeue(), 3, 0);
@@ -81,7 +81,7 @@ namespace UnitTest
         public void TestLeakyBucketPriority()
         {
             QueueBuffer controller = new QueueBuffer();
-            controller.Enqueue(new Packet(1, 0), 1);
+            controller.Enqueue(NewPacket(1, 0), 1);
         }
 
         public PriorityBuffer ConstructPriorityController()
@@ -98,10 +98,10 @@ namespace UnitTest
         {
             PriorityBuffer controller = ConstructPriorityController();
 
-            controller.Enqueue(new Packet(1, 0), 0);
-            controller.Enqueue(new Packet(2, 2), 2);
-            controller.Enqueue(new Packet(3, 1), 1);
-            controller.Enqueue(new Packet(4, 1), 1);
+            controller.Enqueue(NewPacket(1, 0), 0);
+            controller.Enqueue(NewPacket(2, 2), 2);
+            controller.Enqueue(NewPacket(3, 1), 1);
+            controller.Enqueue(NewPacket(4, 1), 1);
 
             AssertPacket(controller.Dequeue(), 1, 0);
             AssertPacket(controller.Dequeue(), 3, 1);
@@ -115,18 +115,18 @@ namespace UnitTest
         {
             PriorityBuffer controller = ConstructPriorityController();
 
-            controller.Enqueue(new Packet(3, 1), 1);
-            controller.Enqueue(new Packet(4, 1), 1);
+            controller.Enqueue(NewPacket(3, 1), 1);
+            controller.Enqueue(NewPacket(4, 1), 1);
 
             AssertPacket(controller.Peek(), 3, 1);
             AssertPacket(controller.Dequeue(), 3, 1);
             AssertPacket(controller.Peek(), 4, 1);
 
-            controller.Enqueue(new Packet(1, 0), 0);
+            controller.Enqueue(NewPacket(1, 0), 0);
 
             AssertPacket(controller.Peek(), 1, 0);
 
-            controller.Enqueue(new Packet(2, 2), 2);
+            controller.Enqueue(NewPacket(2, 2), 2);
 
             AssertPacket(controller.Peek(), 1, 0);
 
@@ -144,7 +144,7 @@ namespace UnitTest
         public void TestPriorityControllerTooLowPriority()
         {
             PriorityBuffer controller = ConstructPriorityController();
-            controller.Enqueue(new Packet(1, -1), -1);
+            controller.Enqueue(NewPacket(1, -1), -1);
         }
 
         [TestMethod]
@@ -152,7 +152,7 @@ namespace UnitTest
         public void TestPriorityControllerTooHighPriority()
         {
             PriorityBuffer controller = ConstructPriorityController();
-            controller.Enqueue(new Packet(1, 3), 3);
+            controller.Enqueue(NewPacket(1, 3), 3);
         }
 
         public BandwidthControlBuffer ConstructBandwidthController(int[] badwidhtAllocation = null)
@@ -169,7 +169,7 @@ namespace UnitTest
         public void TestBandwidthControllerTooLowPriority()
         {
             BandwidthControlBuffer controller = ConstructBandwidthController();
-            controller.Enqueue(new Packet(1, -1), -1);
+            controller.Enqueue(NewPacket(1, -1), -1);
         }
 
         [TestMethod]
@@ -177,14 +177,14 @@ namespace UnitTest
         public void TestBandwidthControllerTooHighPriority()
         {
             BandwidthControlBuffer controller = ConstructBandwidthController();
-            controller.Enqueue(new Packet(1, 3), 3);
+            controller.Enqueue(NewPacket(1, 3), 3);
         }
 
         [TestMethod]
         public void TestBandwidthControllerBasic()
         {
             BandwidthControlBuffer controller = ConstructBandwidthController();
-            controller.Enqueue(new Packet(1, 0), 0);
+            controller.Enqueue(NewPacket(1, 0), 0);
             AssertPacket(controller.Peek(), 1, 0);
             AssertPacket(controller.Dequeue(), 1, 0);
             Assert.AreEqual(controller.Peek(), null);
@@ -192,21 +192,21 @@ namespace UnitTest
             Assert.AreEqual(controller.Peek(), null);
 
 
-            controller.Enqueue(new Packet(1, 0), 0);
+            controller.Enqueue(NewPacket(1, 0), 0);
             AssertPacket(controller.Peek(), 1, 0);
             AssertPacket(controller.Dequeue(), 1, 0);
             Assert.AreEqual(controller.Peek(), null);
             Assert.AreEqual(controller.Dequeue(), null);
             Assert.AreEqual(controller.Peek(), null);
 
-            controller.Enqueue(new Packet(1, 2), 2);
+            controller.Enqueue(NewPacket(1, 2), 2);
             AssertPacket(controller.Peek(), 1, 2);
             AssertPacket(controller.Dequeue(), 1, 2);
             Assert.AreEqual(controller.Peek(), null);
             Assert.AreEqual(controller.Dequeue(), null);
             Assert.AreEqual(controller.Peek(), null);
 
-            controller.Enqueue(new Packet(1, 1), 1);
+            controller.Enqueue(NewPacket(1, 1), 1);
             AssertPacket(controller.Peek(), 1, 1);
             AssertPacket(controller.Dequeue(), 1, 1);
             Assert.AreEqual(controller.Peek(), null);
@@ -223,15 +223,15 @@ namespace UnitTest
 
             for (int i = 0; i < totalPacket; i++)
             {
-                controller.Enqueue(new Packet(r.Next(1, 64), 0), 0);
-                controller.Enqueue(new Packet(r.Next(1, 64), 1), 1);
-                controller.Enqueue(new Packet(r.Next(1, 64), 2), 2);
+                controller.Enqueue(NewPacket(r.Next(1, 64), 0), 0);
+                controller.Enqueue(NewPacket(r.Next(1, 64), 1), 1);
+                controller.Enqueue(NewPacket(r.Next(1, 64), 2), 2);
             }
 
             for (int i = 0; i < totalPacket * 3 / 4; i++)
             {
                 Packet next = controller.Dequeue();
-                bandwidthCount[next.priority] += next.length;
+                bandwidthCount[next.Data.ID] += next.GetLength();
                 nPacket++;
             }
 
@@ -267,7 +267,7 @@ namespace UnitTest
         public void TestGenericControllerTooLowPriority()
         {
             GenericController controller = new GenericController();
-            controller.Enqueue(new Packet(1, -1), -1);
+            controller.Enqueue(NewPacket(1, -1), -1);
         }
 
         [TestMethod]
@@ -275,7 +275,7 @@ namespace UnitTest
         public void TestGenericControllerTooHighPriority()
         {
             GenericController controller = new GenericController();
-            controller.Enqueue(new Packet(1, 3), 5);
+            controller.Enqueue(NewPacket(1, 3), 5);
         }
 
         [TestMethod]
@@ -283,7 +283,7 @@ namespace UnitTest
         public void TestGenericControllerTooLowPriority2()
         {
             GenericController controller = new GenericController();
-            controller.Enqueue(new Packet(1, -1), (GenericController.Priority)(-1));
+            controller.Enqueue(NewPacket(1, -1), (GenericController.Priority)(-1));
         }
 
         [TestMethod]
@@ -291,7 +291,7 @@ namespace UnitTest
         public void TestGenericControllerTooHighPriority2()
         {
             GenericController controller = new GenericController();
-            controller.Enqueue(new Packet(1, 3), (GenericController.Priority)5);
+            controller.Enqueue(NewPacket(1, 3), (GenericController.Priority)5);
         }
 
 
@@ -299,11 +299,11 @@ namespace UnitTest
         public void TestGenericController()
         {
             GenericController controller = new GenericController();
-            controller.Enqueue(new Packet(1, 0), GenericController.Priority.MEDIUM);
-            controller.Enqueue(new Packet(2, 0), GenericController.Priority.LOW);
-            controller.Enqueue(new Packet(3, 0), GenericController.Priority.HIGH);
-            controller.Enqueue(new Packet(4, 0), GenericController.Priority.EMERGENT);
-            controller.Enqueue(new Packet(5, 0), GenericController.Priority.LOWEST);
+            controller.Enqueue(NewPacket(1, 0), GenericController.Priority.MEDIUM);
+            controller.Enqueue(NewPacket(2, 0), GenericController.Priority.LOW);
+            controller.Enqueue(NewPacket(3, 0), GenericController.Priority.HIGH);
+            controller.Enqueue(NewPacket(4, 0), GenericController.Priority.EMERGENT);
+            controller.Enqueue(NewPacket(5, 0), GenericController.Priority.LOWEST);
 
             AssertPacket(controller.Peek(), 4, 0);
             AssertPacket(controller.Dequeue(), 4, 0);

--- a/UnitTest/TestPacketBuffer.cs
+++ b/UnitTest/TestPacketBuffer.cs
@@ -320,10 +320,16 @@ namespace UnitTest
         }
 
         [TestMethod]
-        public void TestCount()
+        public void TestCountAndIsEmpty()
         {
             GenericController controller = new GenericController();
+
+            Assert.AreEqual(false, controller.IsEmpty());
+
             controller.Enqueue(NewPacket(10, 0), 0);
+            
+            Assert.AreEqual(true, controller.IsEmpty());
+
             controller.Enqueue(NewPacket(10, 0), 0);
             controller.Enqueue(NewPacket(10, 1), 1);
             controller.Enqueue(NewPacket(10, 1), 1);
@@ -332,7 +338,14 @@ namespace UnitTest
             controller.Enqueue(NewPacket(10, 3), 3);
             controller.Enqueue(NewPacket(10, 4), 4);
 
+            Assert.AreEqual(true, controller.IsEmpty());
+
             Assert.AreEqual(8, controller.Count);
+
+            for (int i = 0; i < 8; i++)
+                controller.Dequeue();
+            
+            Assert.AreEqual(false, controller.IsEmpty());
         }
     }
 }

--- a/UnitTest/TestPacketBuffer.cs
+++ b/UnitTest/TestPacketBuffer.cs
@@ -283,7 +283,7 @@ namespace UnitTest
         public void TestGenericControllerTooLowPriority2()
         {
             GenericController controller = new GenericController();
-            controller.Enqueue(NewPacket(1, -1), (GenericController.Priority)(-1));
+            controller.Enqueue(NewPacket(1, -1), (PacketPriority)(-1));
         }
 
         [TestMethod]
@@ -291,7 +291,7 @@ namespace UnitTest
         public void TestGenericControllerTooHighPriority2()
         {
             GenericController controller = new GenericController();
-            controller.Enqueue(NewPacket(1, 3), (GenericController.Priority)5);
+            controller.Enqueue(NewPacket(1, 3), (PacketPriority) 5);
         }
 
 
@@ -299,11 +299,11 @@ namespace UnitTest
         public void TestGenericController()
         {
             GenericController controller = new GenericController();
-            controller.Enqueue(NewPacket(1, 0), GenericController.Priority.MEDIUM);
-            controller.Enqueue(NewPacket(2, 0), GenericController.Priority.LOW);
-            controller.Enqueue(NewPacket(3, 0), GenericController.Priority.HIGH);
-            controller.Enqueue(NewPacket(4, 0), GenericController.Priority.EMERGENT);
-            controller.Enqueue(NewPacket(5, 0), GenericController.Priority.LOWEST);
+            controller.Enqueue(NewPacket(1, 0), PacketPriority.MEDIUM);
+            controller.Enqueue(NewPacket(2, 0), PacketPriority.LOW);
+            controller.Enqueue(NewPacket(3, 0), PacketPriority.HIGH);
+            controller.Enqueue(NewPacket(4, 0), PacketPriority.EMERGENT);
+            controller.Enqueue(NewPacket(5, 0), PacketPriority.LOWEST);
 
             AssertPacket(controller.Peek(), 4, 0);
             AssertPacket(controller.Dequeue(), 4, 0);
@@ -324,11 +324,11 @@ namespace UnitTest
         {
             GenericController controller = new GenericController();
 
-            Assert.AreEqual(false, controller.IsEmpty());
+            Assert.AreEqual(true, controller.IsEmpty());
 
             controller.Enqueue(NewPacket(10, 0), 0);
             
-            Assert.AreEqual(true, controller.IsEmpty());
+            Assert.AreEqual(false, controller.IsEmpty());
 
             controller.Enqueue(NewPacket(10, 0), 0);
             controller.Enqueue(NewPacket(10, 1), 1);
@@ -338,14 +338,14 @@ namespace UnitTest
             controller.Enqueue(NewPacket(10, 3), 3);
             controller.Enqueue(NewPacket(10, 4), 4);
 
-            Assert.AreEqual(true, controller.IsEmpty());
+            Assert.AreEqual(false, controller.IsEmpty());
 
             Assert.AreEqual(8, controller.Count);
 
             for (int i = 0; i < 8; i++)
                 controller.Dequeue();
             
-            Assert.AreEqual(false, controller.IsEmpty());
+            Assert.AreEqual(true, controller.IsEmpty());
         }
     }
 }

--- a/UnitTest/TestPacketBuffer.cs
+++ b/UnitTest/TestPacketBuffer.cs
@@ -1,0 +1,322 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Scarlet.Communications;
+
+namespace UnitTest
+{
+    [TestClass]
+    public class UnitTestPacketBuffer
+    {
+        private TestContext testContextInstance;
+
+        /// <summary>
+        /// Gets or sets the test context which provides
+        /// information about and functionality for the current test run.
+        /// </summary>
+        public TestContext TestContext
+        {
+            get
+            {
+                return testContextInstance;
+            }
+            set
+            {
+                testContextInstance = value;
+            }
+        }
+
+        public static Packet NewPacket(int length, int priority)
+        {
+
+        }
+
+        public static void AssertPacket(Packet p, int length, int priority)
+        {
+            Assert.AreEqual(p.length, length);
+            Assert.AreEqual(p.priority, priority);
+        }
+
+        [TestMethod]
+        public void TestLeakyBucketEmpty()
+        {
+            QueueBuffer controller = new QueueBuffer();
+
+            Assert.AreEqual(controller.Peek(), null);
+            Assert.AreEqual(controller.Dequeue(), null);
+
+            controller.Enqueue(new Packet(10, 0));
+            AssertPacket(controller.Peek(), 10, 0);
+            AssertPacket(controller.Dequeue(), 10, 0);
+            Assert.AreEqual(controller.Peek(), null);
+            Assert.AreEqual(controller.Dequeue(), null);
+        }
+
+        [TestMethod]
+        public void TestLeakyBucketCapacity()
+        {
+            QueueBuffer controller = new QueueBuffer();
+            int capacity = 200000;
+            for (int i = 0; i < capacity; i++)
+                controller.Enqueue(new Packet(10, 0));
+            controller.Peek();
+            for (int i = 0; i < capacity; i++)
+                controller.Dequeue();
+        }
+
+        [TestMethod]
+        public void TestLeakyBucketOrder()
+        {
+            QueueBuffer controller = new QueueBuffer();
+            controller.Enqueue(new Packet(1, 0));
+            controller.Enqueue(new Packet(2, 0));
+            controller.Enqueue(new Packet(3, 0));
+            AssertPacket(controller.Dequeue(), 1, 0);
+            AssertPacket(controller.Dequeue(), 2, 0);
+            AssertPacket(controller.Dequeue(), 3, 0);
+            Assert.AreEqual(controller.Dequeue(), null);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void TestLeakyBucketPriority()
+        {
+            QueueBuffer controller = new QueueBuffer();
+            controller.Enqueue(new Packet(1, 0), 1);
+        }
+
+        public PriorityBuffer ConstructPriorityController()
+        {
+            QueueBuffer[] sub = new QueueBuffer[3];
+            sub[0] = new QueueBuffer();
+            sub[1] = new QueueBuffer();
+            sub[2] = new QueueBuffer();
+            return new PriorityBuffer(sub);
+        }
+
+        [TestMethod]
+        public void TestPriorityControllerOrder()
+        {
+            PriorityBuffer controller = ConstructPriorityController();
+
+            controller.Enqueue(new Packet(1, 0), 0);
+            controller.Enqueue(new Packet(2, 2), 2);
+            controller.Enqueue(new Packet(3, 1), 1);
+            controller.Enqueue(new Packet(4, 1), 1);
+
+            AssertPacket(controller.Dequeue(), 1, 0);
+            AssertPacket(controller.Dequeue(), 3, 1);
+            AssertPacket(controller.Dequeue(), 4, 1);
+            AssertPacket(controller.Dequeue(), 2, 2);
+            Assert.AreEqual(controller.Dequeue(), null);
+        }
+
+        [TestMethod]
+        public void TestPriorityControllerPeek()
+        {
+            PriorityBuffer controller = ConstructPriorityController();
+
+            controller.Enqueue(new Packet(3, 1), 1);
+            controller.Enqueue(new Packet(4, 1), 1);
+
+            AssertPacket(controller.Peek(), 3, 1);
+            AssertPacket(controller.Dequeue(), 3, 1);
+            AssertPacket(controller.Peek(), 4, 1);
+
+            controller.Enqueue(new Packet(1, 0), 0);
+
+            AssertPacket(controller.Peek(), 1, 0);
+
+            controller.Enqueue(new Packet(2, 2), 2);
+
+            AssertPacket(controller.Peek(), 1, 0);
+
+            AssertPacket(controller.Dequeue(), 1, 0);
+            AssertPacket(controller.Dequeue(), 4, 1);
+            AssertPacket(controller.Dequeue(), 2, 2);
+
+            Assert.AreEqual(controller.Peek(), null);
+            Assert.AreEqual(controller.Dequeue(), null);
+            Assert.AreEqual(controller.Peek(), null);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void TestPriorityControllerTooLowPriority()
+        {
+            PriorityBuffer controller = ConstructPriorityController();
+            controller.Enqueue(new Packet(1, -1), -1);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void TestPriorityControllerTooHighPriority()
+        {
+            PriorityBuffer controller = ConstructPriorityController();
+            controller.Enqueue(new Packet(1, 3), 3);
+        }
+
+        public BandwidthControlBuffer ConstructBandwidthController(int[] badwidhtAllocation = null)
+        {
+            QueueBuffer[] sub = new QueueBuffer[3];
+            sub[0] = new QueueBuffer();
+            sub[1] = new QueueBuffer();
+            sub[2] = new QueueBuffer();
+            return new BandwidthControlBuffer(sub, badwidhtAllocation, 512);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void TestBandwidthControllerTooLowPriority()
+        {
+            BandwidthControlBuffer controller = ConstructBandwidthController();
+            controller.Enqueue(new Packet(1, -1), -1);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void TestBandwidthControllerTooHighPriority()
+        {
+            BandwidthControlBuffer controller = ConstructBandwidthController();
+            controller.Enqueue(new Packet(1, 3), 3);
+        }
+
+        [TestMethod]
+        public void TestBandwidthControllerBasic()
+        {
+            BandwidthControlBuffer controller = ConstructBandwidthController();
+            controller.Enqueue(new Packet(1, 0), 0);
+            AssertPacket(controller.Peek(), 1, 0);
+            AssertPacket(controller.Dequeue(), 1, 0);
+            Assert.AreEqual(controller.Peek(), null);
+            Assert.AreEqual(controller.Dequeue(), null);
+            Assert.AreEqual(controller.Peek(), null);
+
+
+            controller.Enqueue(new Packet(1, 0), 0);
+            AssertPacket(controller.Peek(), 1, 0);
+            AssertPacket(controller.Dequeue(), 1, 0);
+            Assert.AreEqual(controller.Peek(), null);
+            Assert.AreEqual(controller.Dequeue(), null);
+            Assert.AreEqual(controller.Peek(), null);
+
+            controller.Enqueue(new Packet(1, 2), 2);
+            AssertPacket(controller.Peek(), 1, 2);
+            AssertPacket(controller.Dequeue(), 1, 2);
+            Assert.AreEqual(controller.Peek(), null);
+            Assert.AreEqual(controller.Dequeue(), null);
+            Assert.AreEqual(controller.Peek(), null);
+
+            controller.Enqueue(new Packet(1, 1), 1);
+            AssertPacket(controller.Peek(), 1, 1);
+            AssertPacket(controller.Dequeue(), 1, 1);
+            Assert.AreEqual(controller.Peek(), null);
+            Assert.AreEqual(controller.Dequeue(), null);
+            Assert.AreEqual(controller.Peek(), null);
+        }
+
+        public void BandwidthControllerPressureTest(Random r, int totalPacket)
+        {
+            int[] bandwidth = { 1, 2, 5 };
+            int[] bandwidthCount = { 0, 0, 0 };
+            int nPacket = 0;
+            BandwidthControlBuffer controller = ConstructBandwidthController(bandwidth);
+
+            for (int i = 0; i < totalPacket; i++)
+            {
+                controller.Enqueue(new Packet(r.Next(1, 64), 0), 0);
+                controller.Enqueue(new Packet(r.Next(1, 64), 1), 1);
+                controller.Enqueue(new Packet(r.Next(1, 64), 2), 2);
+            }
+
+            for (int i = 0; i < totalPacket * 3 / 4; i++)
+            {
+                Packet next = controller.Dequeue();
+                bandwidthCount[next.priority] += next.length;
+                nPacket++;
+            }
+
+            if (totalPacket > 10000)
+            {
+                Assert.AreEqual((double)bandwidthCount[0] / bandwidthCount[1], (double)bandwidth[0] / bandwidth[1], 0.1);
+                Assert.AreEqual((double)bandwidthCount[2] / bandwidthCount[1], (double)bandwidth[2] / bandwidth[1], 0.1);
+            }
+
+            testContextInstance.WriteLine("Actural bandwidth: " + string.Join(", ", bandwidthCount));
+
+            while (controller.Peek() != null)
+            {
+                controller.Dequeue();
+                nPacket++;
+            }
+
+            Assert.AreEqual(nPacket, totalPacket * 3);
+        }
+
+        [TestMethod]
+        public void TestBandwidthControllerPressureTest()
+        {
+            Random r = new Random();
+            BandwidthControllerPressureTest(r, 20000);
+
+            for (int i = 0; i < 2000; i++)
+                BandwidthControllerPressureTest(r, 10);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void TestGenericControllerTooLowPriority()
+        {
+            GenericController controller = new GenericController();
+            controller.Enqueue(new Packet(1, -1), -1);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void TestGenericControllerTooHighPriority()
+        {
+            GenericController controller = new GenericController();
+            controller.Enqueue(new Packet(1, 3), 5);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void TestGenericControllerTooLowPriority2()
+        {
+            GenericController controller = new GenericController();
+            controller.Enqueue(new Packet(1, -1), (GenericController.Priority)(-1));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void TestGenericControllerTooHighPriority2()
+        {
+            GenericController controller = new GenericController();
+            controller.Enqueue(new Packet(1, 3), (GenericController.Priority)5);
+        }
+
+
+        [TestMethod]
+        public void TestGenericController()
+        {
+            GenericController controller = new GenericController();
+            controller.Enqueue(new Packet(1, 0), GenericController.Priority.MEDIUM);
+            controller.Enqueue(new Packet(2, 0), GenericController.Priority.LOW);
+            controller.Enqueue(new Packet(3, 0), GenericController.Priority.HIGH);
+            controller.Enqueue(new Packet(4, 0), GenericController.Priority.EMERGENT);
+            controller.Enqueue(new Packet(5, 0), GenericController.Priority.LOWEST);
+
+            AssertPacket(controller.Peek(), 4, 0);
+            AssertPacket(controller.Dequeue(), 4, 0);
+            AssertPacket(controller.Dequeue(), 3, 0);
+            AssertPacket(controller.Dequeue(), 1, 0);
+            AssertPacket(controller.Peek(), 2, 0);
+            AssertPacket(controller.Dequeue(), 2, 0);
+            AssertPacket(controller.Peek(), 5, 0);
+            AssertPacket(controller.Dequeue(), 5, 0);
+
+            Assert.AreEqual(controller.Peek(), null);
+            Assert.AreEqual(controller.Dequeue(), null);
+            Assert.AreEqual(controller.Peek(), null);
+        }
+    }
+}

--- a/UnitTest/UnitTest.csproj
+++ b/UnitTest/UnitTest.csproj
@@ -48,6 +48,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="TestClientAndServer.cs" />
     <Compile Include="TestPacketBuffer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/UnitTest/UnitTest.csproj
+++ b/UnitTest/UnitTest.csproj
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{275370AF-621E-49B7-965F-88BDC665B287}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>UnitTest</RootNamespace>
+    <AssemblyName>UnitTest</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.1.18\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.1.18\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="TestPacketBuffer.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Scarlet.csproj">
+      <Project>{eb8d6fe6-e3dd-4049-89a2-f636c6d70477}</Project>
+      <Name>Scarlet</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/UnitTest/packages.config
+++ b/UnitTest/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="1.1.18" targetFramework="net461" />
+  <package id="MSTest.TestFramework" version="1.1.18" targetFramework="net461" />
+</packages>


### PR DESCRIPTION
Summary:

* Added `PacketBuffer.cs`
* Integrated priority-based packet buffer into `Client` and `Server`
* Added unit test project

---------------------------------------

`Communications` in `Communications/PacketBuffer.cs`:
* New abstract class `PacketBuffer`
* New class `QueueBuffer`
* New class `PriorityBuffer`
* New class `BandwidthControlBuffer`
* New class `GenericController`

---------------------------------------

`Communications.Packet` in `Communication/Packet.cs`:
* New method `GetLength`

---------------------------------------

`Communications.Client` in `Communications/Client.cs`:
* New public-get private-set field `DefaultPriority`
* Field type change: `SendQueue` from `Queue<Packet>` to `PacketBuffer`
* Field type change: `ReceiveQueue` from `Queue<Packet>` to `QueueBuffer`
* Parameter list change: `Start` has new optional parameter `UsePriorityQueue`
* Parameter list change: `Send` has new optional parameter `Priority`
* Return value change: `Send` will return `false` if the packet is not added to queue
* Behavior change: `SendPackets` won't clone packet because packet is already cloned before adding to buffer.

---------------------------------------

`Communications.Server` in `Communications/Server.cs`:
* New public-get private-set field `PriorityQueueEnabled`
* New public-get private-set field `DefaultPriority`
* Field type change: `SendQueues` from `Dictionary<string, Queue<Packet>>` to ` Dictionary<string, PacketBuffer>`
* Field type change: `ReceiveQueue` from `Queue<Packet>` to `QueueBuffer`
* Parameter list change: `Start` has new optional parameter `UsePriorityQueue`
* Parameter list change: `Send` has new optional parameter `Priority`
* New private method: `CreateBufferIfClientIsNew`

---------------------------------------

`Communications` in `Communications/Constants.cs`:
* New type `PacketPriority`