### PR TITLE
Adding SetDelay(float) to IPWMOutput

### DIFF
--- a/IO/BeagleBone/PWMDeviceBBB.cs
+++ b/IO/BeagleBone/PWMDeviceBBB.cs
@@ -1,7 +1,7 @@
-﻿using BBBCSIO;
-using Scarlet.Utilities;
-using System;
+﻿using System;
 using System.IO;
+using BBBCSIO;
+using Scarlet.Utilities;
 
 namespace Scarlet.IO.BeagleBone
 {
@@ -38,42 +38,6 @@ namespace Scarlet.IO.BeagleBone
         public static PWMDeviceBBB PWMDevice1 { get; private set; }
         public static PWMDeviceBBB PWMDevice2 { get; private set; }
 
-        /// <summary> Prepares the given PWM ports for use. Should only be called from BeagleBone.Initialize(). </summary>
-        static internal void Initialize(bool[] EnableBuses)
-        {
-            if (EnableBuses == null || EnableBuses.Length != 3) { throw new Exception("Invalid enable array given to PWMBBB.Initialize."); }
-            //                                                             A1            A2                             B1            B2
-            if (EnableBuses[0]) { PWMDevice0 = new PWMDeviceBBB(new BBBPin[] { BBBPin.P9_22, BBBPin.P9_31 }, new BBBPin[] { BBBPin.P9_21, BBBPin.P9_29 }); }
-            if (EnableBuses[1]) { PWMDevice1 = new PWMDeviceBBB(new BBBPin[] { BBBPin.P9_14, BBBPin.P8_36 }, new BBBPin[] { BBBPin.P9_16, BBBPin.P8_34 }); }
-            if (EnableBuses[2]) { PWMDevice2 = new PWMDeviceBBB(new BBBPin[] { BBBPin.P8_19, BBBPin.P8_45 }, new BBBPin[] { BBBPin.P8_13, BBBPin.P8_46 }); }
-        }
-
-        /// <summary> Converts a pin number to the corresponding PWM device and output number. Needed as every output is connected to 2 physical pins. </summary>
-        static internal PWMPortEnum PinToPWMID(BBBPin Pin)
-        {
-            switch(Pin)
-            {
-                case BBBPin.P9_22:
-                case BBBPin.P9_31: return PWMPortEnum.PWM0_A;
-
-                case BBBPin.P9_21:
-                case BBBPin.P9_29: return PWMPortEnum.PWM0_B;
-
-                case BBBPin.P9_14:
-                case BBBPin.P8_36: return PWMPortEnum.PWM1_A;
-
-                case BBBPin.P9_16:
-                case BBBPin.P8_34: return PWMPortEnum.PWM1_B;
-
-                case BBBPin.P8_19:
-                case BBBPin.P8_45: return PWMPortEnum.PWM2_A;
-
-                case BBBPin.P8_13:
-                case BBBPin.P8_46: return PWMPortEnum.PWM2_B;
-            }
-            return PWMPortEnum.PWM_NONE;
-        }
-
         public static PWMOutputBBB GetFromPin(BBBPin Pin)
         {
             switch (Pin)
@@ -97,6 +61,43 @@ namespace Scarlet.IO.BeagleBone
                 case BBBPin.P8_46: return PWMDevice2.OutputB;
             }
             return null;
+        }
+
+        /// <summary> Prepares the given PWM ports for use. Should only be called from BeagleBone.Initialize(). </summary>
+        internal static void Initialize(bool[] EnableBuses)
+        {
+            if (EnableBuses == null || EnableBuses.Length != 3) { throw new Exception("Invalid enable array given to PWMBBB.Initialize."); }
+
+            //                                                             A1            A2                             B1            B2
+            if (EnableBuses[0]) { PWMDevice0 = new PWMDeviceBBB(new BBBPin[] { BBBPin.P9_22, BBBPin.P9_31 }, new BBBPin[] { BBBPin.P9_21, BBBPin.P9_29 }); }
+            if (EnableBuses[1]) { PWMDevice1 = new PWMDeviceBBB(new BBBPin[] { BBBPin.P9_14, BBBPin.P8_36 }, new BBBPin[] { BBBPin.P9_16, BBBPin.P8_34 }); }
+            if (EnableBuses[2]) { PWMDevice2 = new PWMDeviceBBB(new BBBPin[] { BBBPin.P8_19, BBBPin.P8_45 }, new BBBPin[] { BBBPin.P8_13, BBBPin.P8_46 }); }
+        }
+
+        /// <summary> Converts a pin number to the corresponding PWM device and output number. Needed as every output is connected to 2 physical pins. </summary>
+        internal static PWMPortEnum PinToPWMID(BBBPin Pin)
+        {
+            switch (Pin)
+            {
+                case BBBPin.P9_22:
+                case BBBPin.P9_31: return PWMPortEnum.PWM0_A;
+
+                case BBBPin.P9_21:
+                case BBBPin.P9_29: return PWMPortEnum.PWM0_B;
+
+                case BBBPin.P9_14:
+                case BBBPin.P8_36: return PWMPortEnum.PWM1_A;
+
+                case BBBPin.P9_16:
+                case BBBPin.P8_34: return PWMPortEnum.PWM1_B;
+
+                case BBBPin.P8_19:
+                case BBBPin.P8_45: return PWMPortEnum.PWM2_A;
+
+                case BBBPin.P8_13:
+                case BBBPin.P8_46: return PWMPortEnum.PWM2_B;
+            }
+            return PWMPortEnum.PWM_NONE;
         }
     }
 
@@ -147,6 +148,7 @@ namespace Scarlet.IO.BeagleBone
         private void Initialize()
         {
             PWMPortEnum Device = PWMBBB.PinToPWMID(this.Pins[0]);
+
             // Final path will be: /sys/devices/platform/ocp/4830_000.epwmss/4830_200.pwm/pwm/pwmchip_/pwm_
             //                                                   x               x                   y    z
             // Where x refers to device #. dev 0 = 0, dev 1 = 2, dev 2 = 4.
@@ -159,9 +161,10 @@ namespace Scarlet.IO.BeagleBone
             // At that point, whatever needed to be set in memory is ready for BBBCSIO's PWMPortMM to take over and work.
             // Why does Linux have to be so damn difficult with everything it does? :(
             string Path = "/sys/devices/platform/ocp";
+
             // Append the memory addresses.
             byte ExportNum = 0;
-            switch(Device)
+            switch (Device)
             {
                 case PWMPortEnum.PWM0_A:
                     Path += "/48300000.epwmss/48300200.pwm/pwm/";
@@ -194,7 +197,7 @@ namespace Scarlet.IO.BeagleBone
             string[] PWMChips = Directory.GetDirectories(Path);
             Log.Output(Log.Severity.DEBUG, Log.Source.HARDWAREIO, "Attempting to find correct pwmchip number...");
             bool FoundPWMChip = false;
-            foreach(string SubdirPath in PWMChips)
+            foreach (string SubdirPath in PWMChips)
             {
                 string Subdir = new DirectoryInfo(SubdirPath).Name;
                 if (Subdir.StartsWith("pwmchip"))
@@ -233,6 +236,10 @@ namespace Scarlet.IO.BeagleBone
             this.DutyCycle = DutyCycle * 100F;
         }
 
+        /// <summary> <c>PWMOutputBBB</c> does not support clock delay. This will do nothing. </summary>
+        /// <param name="ClockDelay"> Does nothing. </param>
+        public void SetDelay(float ClockDelay) { }
+
         /// <summary> Sets the output state. </summary>
         public void SetEnabled(bool Enabled) { this.Port.RunState = Enabled; }
 
@@ -247,8 +254,5 @@ namespace Scarlet.IO.BeagleBone
         {
             if (this.DutyCycle != -1) { this.Port.DutyPercent = this.DutyCycle; }
         }
-
-        /// <summary> <c>PWMOutputBBB</c> does not support clock delay. This will do nothing. </summary>
-        public void SetDelay(float ClockDelay) { }
     }
 }

--- a/IO/BeagleBone/PWMDeviceBBB.cs
+++ b/IO/BeagleBone/PWMDeviceBBB.cs
@@ -38,6 +38,9 @@ namespace Scarlet.IO.BeagleBone
         public static PWMDeviceBBB PWMDevice1 { get; private set; }
         public static PWMDeviceBBB PWMDevice2 { get; private set; }
 
+        /// <summary> Gets the PWM output corresponding to a given pin on the BeagleBone Black. </summary>
+        /// <param name="Pin"> The pin to find a PWM output associated with. </param>
+        /// <returns> A <c>PWMOutputBBB</c>, or null if the given pin is not valid. </returns>
         public static PWMOutputBBB GetFromPin(BBBPin Pin)
         {
             switch (Pin)

--- a/IO/BeagleBone/PWMDeviceBBB.cs
+++ b/IO/BeagleBone/PWMDeviceBBB.cs
@@ -247,5 +247,8 @@ namespace Scarlet.IO.BeagleBone
         {
             if (this.DutyCycle != -1) { this.Port.DutyPercent = this.DutyCycle; }
         }
+
+        /// <summary> PWMDeviceBBB does not support clock delay. This will do nothing. </summary>
+        public void SetDelay(float ClockDelay) { }
     }
 }

--- a/IO/BeagleBone/PWMDeviceBBB.cs
+++ b/IO/BeagleBone/PWMDeviceBBB.cs
@@ -248,7 +248,7 @@ namespace Scarlet.IO.BeagleBone
             if (this.DutyCycle != -1) { this.Port.DutyPercent = this.DutyCycle; }
         }
 
-        /// <summary> PWMDeviceBBB does not support clock delay. This will do nothing. </summary>
+        /// <summary> <c>PWMOutputBBB</c> does not support clock delay. This will do nothing. </summary>
         public void SetDelay(float ClockDelay) { }
     }
 }

--- a/IO/IPWMOutput.cs
+++ b/IO/IPWMOutput.cs
@@ -10,6 +10,11 @@
         /// <param name="DutyCycle"> % duty cycle from 0.0 to 1.0. </param>
         void SetOutput(float DutyCycle);
 
+        /// <summary> Sets the delay time of the cycle start. </summary>
+        /// <remarks> Only useful for devices that have multiple PWM outputs that share a clock, and you need custom synchronization. Not all devices will support this, if they do not, this setting will simply not apply. </remarks>
+        /// <param name="ClockDelay"> % of a clock cycle to delay the leading edge by, from 0.0 to (exclusive) 1.0. </param>
+        void SetDelay(float ClockDelay);
+
         /// <summary> Turns on/off the PWM output device. May have different results on different platforms. </summary>
         void SetEnabled(bool Enable);
 

--- a/UnitTest/MotorTesting/TestablePWMOutput.cs
+++ b/UnitTest/MotorTesting/TestablePWMOutput.cs
@@ -11,9 +11,12 @@ namespace UnitTest
     {
         public float Frequency { get; private set; }
         public float DutyCycle { get; private set; }
+        public float Delay { get; private set; }
         public bool Enabled { get; private set; }
 
         public void Dispose() { }
+
+        public void SetDelay(float ClockDelay) { this.Delay = ClockDelay; }
 
         public void SetEnabled(bool Enable) { this.Enabled = Enable; }
 


### PR DESCRIPTION
Fixes #38 
Devices like the `PCA9685` support clock delays, and to be able use them effectively, I wanted to standardize this onto the PWM output interface. Devices like `PWMOutputBBB` that do not have the capability are required to simply do nothing, and note it in their comment.