### PR TITLE
PCA9685 Output Polarity

### DIFF
--- a/Components/Outputs/PCA9685.cs
+++ b/Components/Outputs/PCA9685.cs
@@ -86,11 +86,22 @@ namespace Scarlet.Components.Outputs
                     ushort OnTicks = (ushort)(Math.Max((this.DutyCycle * 4096) - 1, 0)); // For how many ticks the output should be on.
                     ushort OffTime = (ushort)((DelayTicks + OnTicks) % 4096); // The time when the state should be negated.
 
-                    this.Config[1] = (byte)((this.Config[1] & 0b1111_0000) | ((DelayTicks >> 8) & 0b1111)); // ON_MSB
-                    this.Config[0] = (byte)(DelayTicks & 0b1111_1111); // ON_LSB
+                    if (!this.Polarity)
+                    {
+                        this.Config[1] = (byte)((this.Config[1] & 0b1111_0000) | ((DelayTicks >> 8) & 0b1111)); // ON_MSB
+                        this.Config[0] = (byte)(DelayTicks & 0b1111_1111); // ON_LSB
 
-                    this.Config[3] = (byte)((this.Config[3] & 0b1111_0000) | ((OffTime >> 8) & 0b1111)); // OFF_MSB
-                    this.Config[2] = (byte)(OffTime & 0b1111_1111); // OFF_LSB
+                        this.Config[3] = (byte)((this.Config[3] & 0b1111_0000) | ((OffTime >> 8) & 0b1111)); // OFF_MSB
+                        this.Config[2] = (byte)(OffTime & 0b1111_1111); // OFF_LSB
+                    }
+                    else
+                    {
+                        this.Config[1] = (byte)((this.Config[1] & 0b1111_0000) | ((OffTime >> 8) & 0b1111)); // ON_MSB
+                        this.Config[0] = (byte)(OffTime & 0b1111_1111); // ON_LSB
+
+                        this.Config[3] = (byte)((this.Config[3] & 0b1111_0000) | ((DelayTicks >> 8) & 0b1111)); // OFF_MSB
+                        this.Config[2] = (byte)(DelayTicks & 0b1111_1111); // OFF_LSB
+                    }
                 }
 
                 this.Parent.SetChannelData(this.Channel, this.Config);

--- a/Components/Outputs/PCA9685.cs
+++ b/Components/Outputs/PCA9685.cs
@@ -265,5 +265,14 @@ namespace Scarlet.Components.Outputs
             else { Register = (byte)((Channel * 4) + FirstLEDRegister); } // Single LED channel
             this.Bus.WriteRegister(this.PartAddress, Register, Data);
         }
+
+        ~PCA9685()
+        {
+            try
+            {
+                this.Bus.WriteRegister(this.PartAddress, 0x00, new byte[] { 0x11 }); // Attempts to put this device into SLEEP mode to shut down outputs.
+            }
+            catch { } // Meh, oh well.
+        }
     }
 }


### PR DESCRIPTION
Fixes #37.

Forgot to implement this originally, setting the output polarity (normally-high vs normally-low) now actually applies.

Additionally, when the PCA9685 object gets garbage collected (falls out of scope, or program exiting), it will now attempt to put the device into SLEEP mode (disabling outputs). This is not guaranteed to happen however, so outputs should still be disabled safely whenever possible!

Also style improvements to get the PCA9685 class up to spec.