### PR TITLE
RPi I/O Thread Safety

### DIFF
--- a/IO/RaspberryPi/I2CBusPi.cs
+++ b/IO/RaspberryPi/I2CBusPi.cs
@@ -8,21 +8,17 @@ namespace Scarlet.IO.RaspberryPi
 {
     public class I2CBusPi : II2CBus
     {
-
-        private int[] DeviceIDs;
         private readonly object BusLock = new object();
+        private int[] DeviceIDs;
 
         public I2CBusPi()
         {
             this.DeviceIDs = new int[0x7F];
         }
 
-        private void CheckDev(byte Address)
-        {
-            if (this.DeviceIDs[Address] < 1) { this.DeviceIDs[Address] = RaspberryPi.I2CSetup(Address); }
-        }
-
-        /// <summary> Reads raw data from the device at the given address. </summary>
+        /// <summary> Reads 8-bit data from the device at the given address. </summary>
+        /// <param name="Address"> The address of the device to read from. </param>
+        /// <param name="DataLength"> How many bytes to read. </param>
         public byte[] Read(byte Address, int DataLength)
         {
             CheckDev(Address);
@@ -37,7 +33,10 @@ namespace Scarlet.IO.RaspberryPi
             return Buffer;
         }
 
-        /// <summary> Requests data from the given device at the specified register. </summary>
+        /// <summary> Requests 8-bit data from the given device at the specified register. </summary>
+        /// <param name="Address"> The address of the device to read from. </param>
+        /// <param name="Register"> The register to start reading data from. </param>
+        /// <param name="DataLength"> How many bytes to read. If more than 1, subsequent registers are polled. </param>
         public byte[] ReadRegister(byte Address, byte Register, int DataLength)
         {
             CheckDev(Address);
@@ -53,6 +52,8 @@ namespace Scarlet.IO.RaspberryPi
         }
 
         /// <summary> Writes the data as given to the device at the specified address. </summary>
+        /// <param name="Address"> The address of the device to write data to. </param>
+        /// <param name="Data"> The 8-bit data to write to the device. </param>
         public void Write(byte Address, byte[] Data)
         {
             CheckDev(Address);
@@ -63,6 +64,9 @@ namespace Scarlet.IO.RaspberryPi
         }
 
         /// <summary> Selects the register in the given device, then writes the given data. </summary>
+        /// <param name="Address"> The address of the device to write data to. </param>
+        /// <param name="Register"> The register to start writing data at. </param>
+        /// <param name="Data"> The 8-bit data to write. If more than 1 byte, subsequent registers are written. </param>
         public void WriteRegister(byte Address, byte Register, byte[] Data)
         {
             CheckDev(Address);
@@ -75,18 +79,32 @@ namespace Scarlet.IO.RaspberryPi
             }
         }
 
+        /// <summary> Writes data to a 16-bit register. </summary>
+        /// <param name="Address"> The address of the device to write to. </param>
+        /// <param name="Register"> The register to write data to. </param>
+        /// <param name="Data"> The 16-bit data to write to the register. </param>
         public void WriteRegister16(byte Address, byte Register, ushort Data)
         {
             CheckDev(Address);
             lock (this.BusLock) { RaspberryPi.I2CWriteRegister16(this.DeviceIDs[Address], Register, Data); }
         }
 
+        /// <summary> Reads data from a 16-bit register. </summary>
+        /// <param name="Address"> The address of the device to read from. </param>
+        /// <param name="Register"> The register to read from. </param>
+        /// <returns> The 16-bit data in the register. </returns>
         public ushort ReadRegister16(byte Address, byte Register)
         {
             CheckDev(Address);
             lock (this.BusLock) { return RaspberryPi.I2CReadRegister16(this.DeviceIDs[Address], Register); }
         }
 
+        /// <summary> Does nothing. </summary>
         public void Dispose() { }
+
+        private void CheckDev(byte Address)
+        {
+            if (this.DeviceIDs[Address] < 1) { this.DeviceIDs[Address] = RaspberryPi.I2CSetup(Address); }
+        }
     }
 }

--- a/IO/RaspberryPi/I2CBusPi.cs
+++ b/IO/RaspberryPi/I2CBusPi.cs
@@ -10,6 +10,7 @@ namespace Scarlet.IO.RaspberryPi
     {
 
         private int[] DeviceIDs;
+        private readonly object BusLock = new object();
 
         public I2CBusPi()
         {
@@ -26,9 +27,12 @@ namespace Scarlet.IO.RaspberryPi
         {
             CheckDev(Address);
             byte[] Buffer = new byte[DataLength];
-            for (int i = 0; i < DataLength; i++)
+            lock (this.BusLock)
             {
-                Buffer[i] = RaspberryPi.I2CRead(this.DeviceIDs[Address]);
+                for (int i = 0; i < DataLength; i++)
+                {
+                    Buffer[i] = RaspberryPi.I2CRead(this.DeviceIDs[Address]);
+                }
             }
             return Buffer;
         }
@@ -38,9 +42,12 @@ namespace Scarlet.IO.RaspberryPi
         {
             CheckDev(Address);
             byte[] Data = new byte[DataLength];
-            for(int i = 0; i < DataLength; i++)
+            lock (this.BusLock)
             {
-                Data[i] = RaspberryPi.I2CReadRegister8(this.DeviceIDs[Address], (byte)(Register + i));
+                for (int i = 0; i < DataLength; i++)
+                {
+                    Data[i] = RaspberryPi.I2CReadRegister8(this.DeviceIDs[Address], (byte)(Register + i));
+                }
             }
             return Data;
         }
@@ -49,35 +56,37 @@ namespace Scarlet.IO.RaspberryPi
         public void Write(byte Address, byte[] Data)
         {
             CheckDev(Address);
-            foreach (byte Byte in Data) { RaspberryPi.I2CWrite(this.DeviceIDs[Address], Byte); }
+            lock (this.BusLock)
+            {
+                foreach (byte Byte in Data) { RaspberryPi.I2CWrite(this.DeviceIDs[Address], Byte); }
+            }
         }
 
         /// <summary> Selects the register in the given device, then writes the given data. </summary>
         public void WriteRegister(byte Address, byte Register, byte[] Data)
         {
             CheckDev(Address);
-            for (int i = 0; i < Data.Length; i++)
+            lock (this.BusLock)
             {
-                RaspberryPi.I2CWriteRegister8(this.DeviceIDs[Address], (byte)(Register + i), Data[i]);
+                for (int i = 0; i < Data.Length; i++)
+                {
+                    RaspberryPi.I2CWriteRegister8(this.DeviceIDs[Address], (byte)(Register + i), Data[i]);
+                }
             }
         }
 
         public void WriteRegister16(byte Address, byte Register, ushort Data)
         {
             CheckDev(Address);
-            RaspberryPi.I2CWriteRegister16(this.DeviceIDs[Address], Register, Data);
+            lock (this.BusLock) { RaspberryPi.I2CWriteRegister16(this.DeviceIDs[Address], Register, Data); }
         }
 
         public ushort ReadRegister16(byte Address, byte Register)
         {
             CheckDev(Address);
-            return RaspberryPi.I2CReadRegister16(this.DeviceIDs[Address], Register);
+            lock (this.BusLock) { return RaspberryPi.I2CReadRegister16(this.DeviceIDs[Address], Register); }
         }
 
-        public void Dispose()
-        {
-            // TODO: Implement this
-            throw new NotImplementedException();
-        }
+        public void Dispose() { }
     }
 }

--- a/IO/RaspberryPi/SPIBusPi.cs
+++ b/IO/RaspberryPi/SPIBusPi.cs
@@ -19,21 +19,26 @@ namespace Scarlet.IO.RaspberryPi
             RaspberryPi.SPISetup(Bus, DEFAULT_SPEED);
         }
 
-        public void SetBusSpeed(int Speed) { RaspberryPi.SPISetup(BusNum, Speed); }
+        public void SetBusSpeed(int Speed) { RaspberryPi.SPISetup(this.BusNum, Speed); }
 
         /// <summary> Simultaneously writes/reads data to/from the device. </summary>
+        /// <param name="DeviceSelect"> The chip select output to use to choose the desired device. </param>
+        /// <param name="Data"> The data to write. </param>
+        /// <param name="DataLength"> The amount of data to read/write. </param>
+        /// <returns> The data provided back by the device. </returns>
         public byte[] Write(IDigitalOut DeviceSelect, byte[] Data, int DataLength)
         {
             byte[] DataReturn;
             lock (this.BusLock)
             {
                 DeviceSelect.SetOutput(false);
-                DataReturn = RaspberryPi.SPIRW(BusNum, Data, DataLength);
+                DataReturn = RaspberryPi.SPIRW(this.BusNum, Data, DataLength);
                 DeviceSelect.SetOutput(true);
             }
             return DataReturn;
         }
 
+        /// <summary> Does nothing. </summary>
         public void Dispose() { }
     }
 }

--- a/IO/RaspberryPi/SPIBusPi.cs
+++ b/IO/RaspberryPi/SPIBusPi.cs
@@ -10,11 +10,12 @@ namespace Scarlet.IO.RaspberryPi
     {
         private const int DEFAULT_SPEED = 50000;
 
-        private int BusNum;
+        private readonly int BusNum;
+        private readonly object BusLock = new object();
 
         public SPIBusPi(int Bus)
         {
-            BusNum = Bus;
+            this.BusNum = Bus;
             RaspberryPi.SPISetup(Bus, DEFAULT_SPEED);
         }
 
@@ -23,9 +24,13 @@ namespace Scarlet.IO.RaspberryPi
         /// <summary> Simultaneously writes/reads data to/from the device. </summary>
         public byte[] Write(IDigitalOut DeviceSelect, byte[] Data, int DataLength)
         {
-            DeviceSelect.SetOutput(false);
-            byte[] DataReturn = RaspberryPi.SPIRW(BusNum, Data, DataLength);
-            DeviceSelect.SetOutput(true);
+            byte[] DataReturn;
+            lock (this.BusLock)
+            {
+                DeviceSelect.SetOutput(false);
+                DataReturn = RaspberryPi.SPIRW(BusNum, Data, DataLength);
+                DeviceSelect.SetOutput(true);
+            }
             return DataReturn;
         }
 


### PR DESCRIPTION
Fixes #50.
It turns out wiringPi is not thread-safe. This should hopefully resolve that.
I don't think we need to do anything for digital I/O, since those are single operations anyways.